### PR TITLE
Add nuget publishing to release action

### DIFF
--- a/.github/workflows/dotnet-release.yml
+++ b/.github/workflows/dotnet-release.yml
@@ -6,9 +6,6 @@ on:
       - master
       - beta
       - pre-release
-  create:
-    tags:
-      - '*'
 
 jobs:
   build:


### PR DESCRIPTION
This pull request enhances the `.github/workflows/dotnet-release.yml` file by adding new triggers and a job for publishing NuGet packages. The most important changes include the addition of a tag creation trigger and a new `publish_nuget` job.

Enhancements to workflow triggers:

* [`.github/workflows/dotnet-release.yml`](diffhunk://#diff-e6db66c698d5cacbdcef2155b9658f2d7d603f53c2bd5b75217af9b408247962R9-R11): Added a trigger for tag creation to the `on:` section to initiate workflows on tag creation.

New job for NuGet package publishing:

* [`.github/workflows/dotnet-release.yml`](diffhunk://#diff-e6db66c698d5cacbdcef2155b9658f2d7d603f53c2bd5b75217af9b408247962R69-R86): Introduced a `publish_nuget` job that depends on the `semantic_release` job. This job includes steps to check out the repository, set up .NET, build the NuGet package, and publish it to NuGet.org.