### PR TITLE
feat(#5): Add useSplitQueries param and upgrade NuGet packages

### DIFF
--- a/RapidRepo.Tests/RapidRepo.Tests.csproj
+++ b/RapidRepo.Tests/RapidRepo.Tests.csproj
@@ -11,14 +11,20 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/RapidRepo/Extensions/IQueryableExtensions.cs
+++ b/RapidRepo/Extensions/IQueryableExtensions.cs
@@ -11,6 +11,7 @@ internal static class IQueryableExtensions
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         bool track = true)
         where TEntity : BaseEntity<TId>
@@ -39,6 +40,11 @@ internal static class IQueryableExtensions
         if (include != null)
         {
             query = include(query);
+        }
+
+        if (useSplitQueries)
+        {
+            query = query.AsSplitQuery();
         }
 
         return query;

--- a/RapidRepo/RapidRepo.csproj
+++ b/RapidRepo/RapidRepo.csproj
@@ -9,12 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="RapidRepo.Tests" />
-    <None Include="..\README.md" Pack="true" PackagePath="\"/>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/RapidRepo/Repositories/BaseRepository.cs
+++ b/RapidRepo/Repositories/BaseRepository.cs
@@ -109,6 +109,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         bool track = true)
     {
@@ -128,6 +129,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         bool track = true,
         CancellationToken cancellationToken = default)
@@ -147,6 +149,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
     public virtual TEntity? GetById(
         TId id,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool track = true,
         bool ignoreQueryFilters = false)
     {
@@ -164,6 +167,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
         TId id,
         Expression<Func<TEntity, TResult>> selector,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false)
     {
         return DbContext
@@ -182,6 +186,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
     public virtual async Task<TEntity?> GetByIdAsync(
         TId id,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool track = true,
         bool ignoreQueryFilters = false,
         CancellationToken cancellationToken = default)
@@ -200,6 +205,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         bool track = true)
     {
@@ -219,6 +225,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         bool track = true,
         CancellationToken cancellationToken = default)
@@ -239,6 +246,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         bool track = true)
     {
@@ -258,6 +266,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         bool track = true,
         CancellationToken cancellationToken = default)
@@ -278,6 +287,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         bool track = true,
         int pageIndex = 1,
@@ -312,6 +322,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         bool track = true,
         int pageIndex = 1,
@@ -346,6 +357,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         bool track = true)
     {
@@ -365,6 +377,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         bool track = true,
         CancellationToken cancellationToken = default)
@@ -385,6 +398,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         bool track = true)
     {
@@ -404,6 +418,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         bool track = true,
         CancellationToken cancellationToken = default)
@@ -448,6 +463,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
         TId id,
         Expression<Func<TEntity, TResult>> selector,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         CancellationToken cancellationToken = default)
     {
@@ -468,6 +484,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false)
     {
         return DbContext
@@ -487,6 +504,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         CancellationToken cancellationToken = default)
     {
@@ -507,6 +525,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false)
     {
         return DbContext
@@ -526,6 +545,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         CancellationToken cancellationToken = default)
     {
@@ -546,6 +566,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false)
     {
         return DbContext
@@ -565,6 +586,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         CancellationToken cancellationToken = default)
     {
@@ -585,6 +607,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false)
     {
         return DbContext
@@ -604,6 +627,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         CancellationToken cancellationToken = default)
     {
@@ -624,6 +648,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false)
     {
         return DbContext
@@ -644,6 +669,7 @@ public abstract class BaseRepository<TEntity, TId> : IRepository<TEntity, TId>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         CancellationToken cancellation = default)
     {

--- a/RapidRepo/Repositories/Interfaces/IRepository.cs
+++ b/RapidRepo/Repositories/Interfaces/IRepository.cs
@@ -33,11 +33,13 @@ public interface IRepository<TEntity, in TKey>
     /// </summary>
     /// <param name="id">The identifier of the entity.</param>
     /// <param name="include">A function to include related entities.</param>
+    /// <param name="useSplitQueries">Whether to use split queries for related entities. See <see href="https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries"/> for more details.</param>
     /// <param name="track">Whether to track the entity in the context.</param>
     /// <param name="ignoreQueryFilters">Whether to ignore query filters.</param>
     /// <returns>The entity with the specified identifier, or null if not found.</returns>
     TEntity? GetById(TKey id,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool track = true,
         bool ignoreQueryFilters = false);
 
@@ -48,11 +50,13 @@ public interface IRepository<TEntity, in TKey>
     /// <param name="id">The identifier of the entity.</param>
     /// <param name="selector">A function to select the result.</param>
     /// <param name="include">A function to include related entities.</param>
+    /// <param name="useSplitQueries">Whether to use split queries for related entities. See <see href="https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries"/> for more details.</param>
     /// <param name="ignoreQueryFilters">Whether to ignore query filters.</param>
     /// <returns>The result of the selector function for the entity with the specified identifier, or null if not found.</returns>
     TResult? GetById<TResult>(TKey id,
         Expression<Func<TEntity, TResult>> selector,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false);
 
     /// <summary>
@@ -60,12 +64,14 @@ public interface IRepository<TEntity, in TKey>
     /// </summary>
     /// <param name="id">The identifier of the entity.</param>
     /// <param name="include">A function to include related entities.</param>
+    /// <param name="useSplitQueries">Whether to use split queries for related entities. See <see href="https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries"/> for more details.</param>
     /// <param name="track">Whether to track the entity in the context.</param>
     /// <param name="ignoreQueryFilters">Whether to ignore query filters.</param>
     /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
     /// <returns>The entity with the specified identifier, or null if not found.</returns>
     Task<TEntity?> GetByIdAsync(TKey id,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool track = true,
         bool ignoreQueryFilters = false,
         CancellationToken cancellationToken = default);
@@ -77,12 +83,14 @@ public interface IRepository<TEntity, in TKey>
     /// <param name="id">The identifier of the entity.</param>
     /// <param name="selector">A function to select the result.</param>
     /// <param name="include">A function to include related entities.</param>
+    /// <param name="useSplitQueries">Whether to use split queries for related entities. See <see href="https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries"/> for more details.</param>
     /// <param name="ignoreQueryFilters">Whether to ignore query filters.</param>
     /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
     /// <returns>The result of the selector function for the entity with the specified identifier, or null if not found.</returns>
     Task<TResult?> GetByIdAsync<TResult>(TKey id,
         Expression<Func<TEntity, TResult>> selector,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         CancellationToken cancellationToken = default);
 
@@ -139,6 +147,7 @@ public interface IRepository<TEntity, in TKey>
     /// <param name="condition">The condition to filter entities.</param>
     /// <param name="orderBy">A function to order the entities.</param>
     /// <param name="include">A function to include related entities.</param>
+    /// <param name="useSplitQueries">Whether to use split queries for related entities. See <see href="https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries"/> for more details.</param>
     /// <param name="ignoreQueryFilters">Whether to ignore query filters.</param>
     /// <param name="track">Whether to track the entity in the context.</param>
     /// <returns>The first entity that matches the condition, or null if no match is found.</returns>
@@ -146,14 +155,27 @@ public interface IRepository<TEntity, in TKey>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         bool track = true);
 
+    /// <summary>
+    /// Gets the first entity that matches the specified condition and applies a selector, or null if no match is found.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <param name="selector">A function to select the result.</param>
+    /// <param name="condition">The condition to filter entities.</param>
+    /// <param name="orderBy">A function to order the entities.</param>
+    /// <param name="include">A function to include related entities.</param>
+    /// <param name="useSplitQueries">Whether to use split queries for related entities. See <see href="https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries"/> for more details.</param>
+    /// <param name="ignoreQueryFilters">Whether to ignore query filters.</param>
+    /// <returns>The result of the selector function for the first entity that matches the condition, or null if no match is found.</returns>
     TResult? GetFirstOrDefault<TResult>(
         Expression<Func<TEntity, TResult>> selector,
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false);
 
     /// <summary>
@@ -162,6 +184,7 @@ public interface IRepository<TEntity, in TKey>
     /// <param name="condition">The condition to filter entities.</param>
     /// <param name="orderBy">A function to order the entities.</param>
     /// <param name="include">A function to include related entities.</param>
+    /// <param name="useSplitQueries">Whether to use split queries for related entities. See <see href="https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries"/> for more details.</param>
     /// <param name="ignoreQueryFilters">Whether to ignore query filters.</param>
     /// <param name="track">Whether to track the entity in the context.</param>
     /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
@@ -169,15 +192,29 @@ public interface IRepository<TEntity, in TKey>
     Task<TEntity?> GetFirstOrDefaultAsync(Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         bool track = true,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Asynchronously gets the first entity that matches the specified condition and applies a selector, or null if no match is found.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <param name="selector">A function to select the result.</param>
+    /// <param name="condition">The condition to filter entities.</param>
+    /// <param name="orderBy">A function to order the entities.</param>
+    /// <param name="include">A function to include related entities.</param>
+    /// <param name="useSplitQueries">Whether to use split queries for related entities. See <see href="https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries"/> for more details.</param>
+    /// <param name="ignoreQueryFilters">Whether to ignore query filters.</param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>The result of the selector function for the first entity that matches the condition, or null if no match is found.</returns>
     Task<TResult?> GetFirstOrDefaultAsync<TResult>(
         Expression<Func<TEntity, TResult>> selector,
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         CancellationToken cancellationToken = default);
 
@@ -187,20 +224,34 @@ public interface IRepository<TEntity, in TKey>
     /// <param name="condition">The condition to filter entities.</param>
     /// <param name="orderBy">A function to order the entities.</param>
     /// <param name="include">A function to include related entities.</param>
+    /// <param name="useSplitQueries">Whether to use split queries for related entities. See <see href="https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries"/> for more details.</param>
     /// <param name="ignoreQueryFilters">Whether to ignore query filters.</param>
     /// <param name="track">Whether to track the entity in the context.</param>
     /// <returns>The first entity that matches the condition.</returns>
     TEntity GetFirst(Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         bool track = true);
 
+    /// <summary>
+    /// Gets the first entity that matches the specified condition and applies a selector.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <param name="selector">A function to select the result.</param>
+    /// <param name="condition">The condition to filter entities.</param>
+    /// <param name="orderBy">A function to order the entities.</param>
+    /// <param name="include">A function to include related entities.</param>
+    /// <param name="useSplitQueries">Whether to use split queries for related entities. See <see href="https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries"/> for more details.</param>
+    /// <param name="ignoreQueryFilters">Whether to ignore query filters.</param>
+    /// <returns>The result of the selector function for the first entity that matches the condition.</returns>
     TResult GetFirst<TResult>(
         Expression<Func<TEntity, TResult>> selector,
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false);
 
     /// <summary>
@@ -209,6 +260,7 @@ public interface IRepository<TEntity, in TKey>
     /// <param name="condition">The condition to filter entities.</param>
     /// <param name="orderBy">A function to order the entities.</param>
     /// <param name="include">A function to include related entities.</param>
+    /// <param name="useSplitQueries">Whether to use split queries for related entities. See <see href="https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries"/> for more details.</param>
     /// <param name="ignoreQueryFilters">Whether to ignore query filters.</param>
     /// <param name="track">Whether to track the entity in the context.</param>
     /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
@@ -216,15 +268,29 @@ public interface IRepository<TEntity, in TKey>
     Task<TEntity> GetFirstAsync(Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         bool track = true,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Asynchronously gets the first entity that matches the specified condition and applies a selector.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <param name="selector">A function to select the result.</param>
+    /// <param name="condition">The condition to filter entities.</param>
+    /// <param name="orderBy">A function to order the entities.</param>
+    /// <param name="include">A function to include related entities.</param>
+    /// <param name="useSplitQueries">Whether to use split queries for related entities. See <see href="https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries"/> for more details.</param>
+    /// <param name="ignoreQueryFilters">Whether to ignore query filters.</param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>The result of the selector function for the first entity that matches the condition.</returns>
     Task<TResult> GetFirstAsync<TResult>(
         Expression<Func<TEntity, TResult>> selector,
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         CancellationToken cancellationToken = default);
 
@@ -234,20 +300,34 @@ public interface IRepository<TEntity, in TKey>
     /// <param name="condition">The condition to filter entities.</param>
     /// <param name="orderBy">A function to order the entities.</param>
     /// <param name="include">A function to include related entities.</param>
+    /// <param name="useSplitQueries">Whether to use split queries for related entities. See <see href="https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries"/> for more details.</param>
     /// <param name="ignoreQueryFilters">Whether to ignore query filters.</param>
     /// <param name="track">Whether to track the entity in the context.</param>
     /// <returns>The single entity that matches the condition, or null if no match is found.</returns>
     TEntity? GetSingleOrDefault(Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         bool track = true);
 
+    /// <summary>
+    /// Gets the single entity that matches the specified condition and applies a selector, or null if no match is found.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <param name="selector">A function to select the result.</param>
+    /// <param name="condition">The condition to filter entities.</param>
+    /// <param name="orderBy">A function to order the entities.</param>
+    /// <param name="include">A function to include related entities.</param>
+    /// <param name="useSplitQueries">Whether to use split queries for related entities. See <see href="https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries"/> for more details.</param>
+    /// <param name="ignoreQueryFilters">Whether to ignore query filters.</param>
+    /// <returns>The result of the selector function for the single entity that matches the condition, or null if no match is found.</returns>
     TResult? GetSingleOrDefault<TResult>(
         Expression<Func<TEntity, TResult>> selector,
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false);
 
     /// <summary>
@@ -256,6 +336,7 @@ public interface IRepository<TEntity, in TKey>
     /// <param name="condition">The condition to filter entities.</param>
     /// <param name="orderBy">A function to order the entities.</param>
     /// <param name="include">A function to include related entities.</param>
+    /// <param name="useSplitQueries">Whether to use split queries for related entities. See <see href="https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries"/> for more details.</param>
     /// <param name="ignoreQueryFilters">Whether to ignore query filters.</param>
     /// <param name="track">Whether to track the entity in the context.</param>
     /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
@@ -264,15 +345,29 @@ public interface IRepository<TEntity, in TKey>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         bool track = true,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Gets the single entity that matches the specified condition and applies a selector, or null if no match is found.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <param name="selector">A function to select the result.</param>
+    /// <param name="condition">The condition to filter entities.</param>
+    /// <param name="orderBy">A function to order the entities.</param>
+    /// <param name="include">A function to include related entities.</param>
+    /// <param name="useSplitQueries">Whether to use split queries for related entities. See <see href="https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries"/> for more details.</param>
+    /// <param name="ignoreQueryFilters">Whether to ignore query filters.</param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>The result of the selector function for the single entity that matches the condition, or null if no match is found.</returns>
     Task<TResult?> GetSingleOrDefaultAsync<TResult>(
         Expression<Func<TEntity, TResult>> selector,
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         CancellationToken cancellationToken = default);
 
@@ -282,20 +377,35 @@ public interface IRepository<TEntity, in TKey>
     /// <param name="condition">The condition to filter entities.</param>
     /// <param name="orderBy">A function to order the entities.</param>
     /// <param name="include">A function to include related entities.</param>
+    /// <param name="useSplitQueries">Whether to use split queries for related entities. See <see href="https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries"/> for more details.</param>
     /// <param name="ignoreQueryFilters">Whether to ignore query filters.</param>
     /// <param name="track">Whether to track the entity in the context.</param>
     /// <returns>The single entity that matches the condition.</returns>
     TEntity GetSingle(Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         bool track = true);
 
+    /// <summary>
+    /// Gets the single entity that matches the specified condition and applies a selector.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result.</typeparam>
+    /// <param name="selector">A function to select the result.</param>
+    /// <param name="condition">The condition to filter entities.</param>
+    /// <param name="orderBy">A function to order the entities.</param>
+    /// <param name="include">A function to include related entities.</param>
+    /// <param name="useSplitQueries">Whether to use split queries for related entities. See <see href="https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries"/> for more details.</param>
+    /// <param name="ignoreQueryFilters">Whether to ignore query filters.</param>
+    /// <param name="track">Whether to track the entity in the context.</param>
+    /// <returns>The result of the selector function for the single entity that matches the condition.</returns>
     TResult GetSingle<TResult>(
         Expression<Func<TEntity, TResult>> selector,
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false);
 
     /// <summary>
@@ -304,6 +414,7 @@ public interface IRepository<TEntity, in TKey>
     /// <param name="condition">The condition to filter entities.</param>
     /// <param name="orderBy">A function to order the entities.</param>
     /// <param name="include">A function to include related entities.</param>
+    /// <param name="useSplitQueries">Whether to use split queries for related entities. See <see href="https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries"/> for more details.</param>
     /// <param name="ignoreQueryFilters">Whether to ignore query filters.</param>
     /// <param name="track">Whether to track the entity in the context.</param>
     /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
@@ -312,6 +423,7 @@ public interface IRepository<TEntity, in TKey>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         bool track = true,
         CancellationToken cancellationToken = default);
@@ -325,6 +437,7 @@ public interface IRepository<TEntity, in TKey>
     /// <param name="condition">The condition to filter entities.</param>
     /// <param name="orderBy">A function to order the entities.</param>
     /// <param name="include">A function to include related entities.</param>
+    /// <param name="useSplitQueries">Whether to use split queries for related entities. See <see href="https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries"/> for more details.</param>
     /// <param name="ignoreQueryFilters">Whether to ignore query filters.</param>
     /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
     /// <returns>The single entity that matches the condition.</returns>
@@ -333,6 +446,7 @@ public interface IRepository<TEntity, in TKey>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         CancellationToken cancellationToken = default);
 
@@ -342,6 +456,7 @@ public interface IRepository<TEntity, in TKey>
     /// <param name="condition">The condition to filter entities.</param>
     /// <param name="orderBy">A function to order the entities.</param>
     /// <param name="include">A function to include related entities.</param>
+    /// <param name="useSplitQueries">Whether to use split queries for related entities. See <see href="https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries"/> for more details.</param>
     /// <param name="ignoreQueryFilters">Whether to ignore query filters.</param>
     /// <param name="track">Whether to track the entity in the context.</param>
     /// <returns>The entities that match the condition.</returns>
@@ -349,6 +464,7 @@ public interface IRepository<TEntity, in TKey>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         bool track = true);
 
@@ -360,6 +476,7 @@ public interface IRepository<TEntity, in TKey>
     /// <param name="condition">The condition to filter entities.</param>
     /// <param name="orderBy">A function to order the entities.</param>
     /// <param name="include">A function to include related entities.</param>
+    /// <param name="useSplitQueries">Whether to use split queries for related entities. See <see href="https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries"/> for more details.</param>
     /// <param name="ignoreQueryFilters">Whether to ignore query filters.</param>
     /// <param name="track">Whether to track the entity in the context.</param>
     /// <returns>The entities that match the condition.</returns>
@@ -368,6 +485,7 @@ public interface IRepository<TEntity, in TKey>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false);
 
     /// <summary>
@@ -376,6 +494,7 @@ public interface IRepository<TEntity, in TKey>
     /// <param name="condition">The condition to filter entities.</param>
     /// <param name="orderBy">A function to order the entities.</param>
     /// <param name="include">A function to include related entities.</param>
+    /// <param name="useSplitQueries">Whether to use split queries for related entities. See <see href="https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries"/> for more details.</param>
     /// <param name="ignoreQueryFilters">Whether to ignore query filters.</param>
     /// <param name="track">Whether to track the entity in the context.</param>
     /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
@@ -384,6 +503,7 @@ public interface IRepository<TEntity, in TKey>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         bool track = true,
         CancellationToken cancellationToken = default);
@@ -396,6 +516,7 @@ public interface IRepository<TEntity, in TKey>
     /// <param name="condition">The condition to filter entities.</param>
     /// <param name="orderBy">A function to order the entities.</param>
     /// <param name="include">A function to include related entities.</param>
+    /// <param name="useSplitQueries">Whether to use split queries for related entities. See <see href="https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries"/> for more details.</param>
     /// <param name="ignoreQueryFilters">Whether to ignore query filters.</param>
     /// <param name="track">Whether to track the entity in the context.</param>
     /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
@@ -405,6 +526,7 @@ public interface IRepository<TEntity, in TKey>
         Expression<Func<TEntity, bool>>? condition = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
         bool ignoreQueryFilters = false,
         CancellationToken cancellation = default);
 }


### PR DESCRIPTION
- Updated `RapidRepo.Tests.csproj` to upgrade NuGet packages and add `PrivateAssets` and `IncludeAssets` attributes.
- Modified `IQueryableExtensions` to add `useSplitQueries` param to `ApplyFilters` method.
- Updated `RapidRepo.csproj` to upgrade `Microsoft.EntityFrameworkCore` and add `Microsoft.EntityFrameworkCore.Relational`.
- Enhanced `BaseRepository<TEntity, TId>` with `useSplitQueries` param in various methods.
- Updated `IRepository<TEntity, in TKey>` interface to include `useSplitQueries` param and updated XML documentation.