### PR TITLE
docs(readme): Revamp and expand documentation for RapidRepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,90 +3,98 @@
 [![Build](https://github.com/tibor-horvath/RapidRepo/actions/workflows/dotnet-build.yml/badge.svg)](https://github.com/tibor-horvath/RapidRepo/actions/workflows/dotnet-build.yml)
 [![Release](https://github.com/tibor-horvath/RapidRepo/actions/workflows/dotnet-release.yml/badge.svg)](https://github.com/tibor-horvath/RapidRepo/actions/workflows/dotnet-release.yml)
 
-## Documentation
+RapidRepo is a repository pattern implementation for .NET applications. It uses Entity Framework Core to provide a clean and consistent data access layer for common CRUD operations.
 
-RapidRepo is a comprehensive repository pattern implementation designed to streamline data access and manipulation in .NET applications. It leverages Entity Framework Core to provide a robust and flexible data access layer, ensuring that common data operations are handled efficiently and consistently.
+## Features
 
-### Purpose
+- Repository and Unit of Work abstractions
+- EF Core-based data access
+- Consistent and reusable CRUD patterns
+- Separation of business logic and persistence logic
+- Built-in auditing (`CreatedAt`, `CreatedBy`, `ModifiedAt`, `ModifiedBy`)
+- Built-in soft delete support (`DeletedAt`, `DeletedBy`)
+- Paged query results via `Paged<T>`
 
-The purpose of RapidRepo is to simplify data access and manipulation in .NET applications by providing a repository pattern implementation. It aims to offer a robust and flexible data access layer using Entity Framework Core.
+## Requirements
 
-### Features
+- .NET 10 SDK
+- Entity Framework Core-compatible `DbContext`
 
-- **Streamlined data access and manipulation**: Provides methods and abstractions that simplify common data operations in .NET applications.
-- **Repository pattern implementation**: Separates data access logic from business logic, offering a structured way to perform CRUD (Create, Read, Update, Delete) operations.
-- **Leveraging Entity Framework Core**: Uses a popular ORM framework to map database tables to .NET objects, simplifying database operations with object-oriented programming techniques.
-- **Efficient and consistent data operations**: Optimizes queries and data retrieval to minimize latency and improve performance, ensuring atomic and reliable data manipulation.
+## Installation
 
-### Usage
+```bash
+dotnet add package RapidRepo
+```
 
-To use RapidRepo in your .NET application:
+## Quick Start
 
-1. Install the RapidRepo NuGet package.
-2. Configure the database connection string in your application's configuration file.
-3. Create a repository class that inherits from the `BaseRepository` class provided by RapidRepo.
-4. Implement any additional custom repository methods as needed.
-5. Use the repository methods to perform data access and manipulation operations in your application.
-
-### Example
 ```csharp
+// 1. Define an entity
 public class Product : BaseEntity<long>
 {
-    public string Name { get; set; }
-    public string Description { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public decimal Price { get; set; }
 }
 
-public interface IProductRepository : IRepository<Product, long>
-{
-   // Add custom methods here
-}   
+// 2. Create a repository interface and implementation
+public interface IProductRepository : IRepository<Product, long> { }
 
 public class ProductRepository : BaseRepository<Product, long>, IProductRepository
-{ 
-    public ProductRepository(DbContext context) 
-    : base(context) 
-    {         
-    }
-    // Add custom methods here
+{
+    public ProductRepository(DbContext context) : base(context) { }
 }
 
-public interface ITestUnitOfWork : IUnitOfWork<Guid>, IDisposable
+// 3. Create a Unit of Work
+public interface IAppUnitOfWork : IUnitOfWork<Guid>, IDisposable
 {
     IProductRepository Products { get; }
 }
 
-public class TestUnitOfWork : UnitOfWork<Guid>, IITestUnitOfWork
+public class AppUnitOfWork : UnitOfWork<Guid>, IAppUnitOfWork
 {
     public IProductRepository Products { get; }
+    public override Guid DefaultUserKey => Guid.Empty;
 
-    public override Guid DefaultUserId => default;
-
-    public UnitOfWork(
-        AppDbContext dbContext,
-        IProductRepository productRepository)
+    public AppUnitOfWork(AppDbContext dbContext, IProductRepository productRepository)
         : base(dbContext)
     {
         Products = productRepository ?? throw new ArgumentNullException(nameof(productRepository));
     }
 }
 
-// Usage in a service public class ProductService
-public class ProductService : IProductService
-{ 
-    private readonly IUnitOfWork _unitOfWork;
+// 4. Register in DI (Program.cs)
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("Default")));
+builder.Services.AddScoped<IProductRepository, ProductRepository>();
+builder.Services.AddScoped<IAppUnitOfWork, AppUnitOfWork>();
 
-    public ProductService(IUnitOfWork unitOfWork)
-    {
-        _unitOfWork = unitOfWork;
-    }
+// 5. Use in a service
+public class ProductService
+{
+    private readonly IAppUnitOfWork _unitOfWork;
+    public ProductService(IAppUnitOfWork unitOfWork) => _unitOfWork = unitOfWork;
 
-    public async Task<List<Product>> GetAllProductsAsync()
+    public async Task<IEnumerable<Product>> GetAllAsync()
+        => await _unitOfWork.Products.GetAllAsync();
+
+    public async Task CreateAsync(Product product)
     {
-        return await _unitOfWork.Products.GetAllAsync();
+        await _unitOfWork.Products.AddAsync(product);
+        await _unitOfWork.CommitAsync();
     }
 }
 ```
 
-### License
+## Documentation
 
-RapidRepo is licensed under the MIT License. See the [LICENSE](./LICENSE) file for more information.
+| Topic | Description |
+|---|---|
+| [Entities](docs/entities.md) | `BaseEntity`, `BaseAuditableEntity`, soft delete |
+| [Repositories](docs/repositories.md) | Interfaces, base classes, custom methods, DI registration |
+| [Unit of Work](docs/unit-of-work.md) | Setup, committing, auditing |
+| [API Reference](docs/api-reference.md) | All read and write methods with parameters |
+| [Advanced Usage](docs/advanced.md) | Filtering, projection, paging, bulk operations |
+
+## License
+
+RapidRepo is licensed under the MIT License. See [LICENSE](./LICENSE) for details.

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -10,7 +10,7 @@ All query methods accept optional `condition`, `orderBy`, and `include` paramete
 var products = await _unitOfWork.Products.GetAllAsync(
     condition: p => p.IsActive && p.Price > 10m,
     orderBy: q => q.OrderByDescending(p => p.Price).ThenBy(p => p.Name),
-    include: q => q.Include(p => p.Category).ThenInclude(c => c.Tags));
+    include: q => q.Include(p => p.Category));
 ```
 
 ---

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,152 @@
+# Advanced Usage
+
+---
+
+## Filtering, sorting, and eager loading
+
+All query methods accept optional `condition`, `orderBy`, and `include` parameters:
+
+```csharp
+var products = await _unitOfWork.Products.GetAllAsync(
+    condition: p => p.IsActive && p.Price > 10m,
+    orderBy: q => q.OrderByDescending(p => p.Price).ThenBy(p => p.Name),
+    include: q => q.Include(p => p.Category).ThenInclude(c => c.Tags));
+```
+
+---
+
+## Projecting to a DTO (selector)
+
+Use a `selector` expression to project results without loading the full entity. This reduces data transfer and avoids materializing objects you don't need.
+
+```csharp
+// Project to a DTO
+record ProductSummary(long Id, string Name, decimal Price);
+
+var summaries = await _unitOfWork.Products.GetAllAsync(
+    selector: p => new ProductSummary(p.Id, p.Name, p.Price),
+    condition: p => p.IsActive,
+    orderBy: q => q.OrderBy(p => p.Name));
+
+// Project to a scalar
+var names = await _unitOfWork.Products.GetAllAsync(
+    selector: p => p.Name);
+```
+
+---
+
+## Paged queries
+
+Use `GetAllPagedAsync` to return a `Paged<T>` result suitable for list views and APIs:
+
+```csharp
+Paged<Product> page = await _unitOfWork.Products.GetAllPagedAsync(
+    condition: p => p.IsActive,
+    orderBy: q => q.OrderBy(p => p.Name),
+    pageIndex: 2,
+    pageSize: 25);
+
+foreach (var item in page.Results)
+{
+    Console.WriteLine(item.Name);
+}
+
+Console.WriteLine($"Page {page.Page} of {page.TotalPages} ({page.TotalCount} total)");
+Console.WriteLine($"Has next: {page.HasNext}, Has previous: {page.HasPrevious}");
+```
+
+---
+
+## Disabling change tracking (read-only queries)
+
+Set `track: false` for queries whose results will not be modified. This avoids the overhead of EF change tracking and improves performance for read-heavy paths:
+
+```csharp
+var products = await _unitOfWork.Products.GetAllAsync(
+    condition: p => p.IsActive,
+    track: false);
+```
+
+---
+
+## Bypassing global query filters
+
+Use `ignoreQueryFilters: true` to see records excluded by global EF query filters (e.g. soft-deleted entities):
+
+```csharp
+var allIncludingDeleted = await _unitOfWork.Products.GetAllAsync(
+    ignoreQueryFilters: true);
+```
+
+---
+
+## Split queries for large includes
+
+When including multiple collection navigations, use `useSplitQueries: true` to avoid a Cartesian explosion. See the [EF Core documentation](https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries) for details.
+
+```csharp
+var products = await _unitOfWork.Products.GetAllAsync(
+    include: q => q.Include(p => p.Tags).Include(p => p.Reviews),
+    useSplitQueries: true);
+```
+
+---
+
+## Bulk insert and update
+
+```csharp
+// Add multiple entities in one commit
+var newProducts = new List<Product>
+{
+    new() { Name = "Widget A", Price = 9.99m },
+    new() { Name = "Widget B", Price = 14.99m },
+};
+
+await _unitOfWork.Products.AddAsync(newProducts);
+await _unitOfWork.CommitAsync(userId: currentUserId);
+
+// Update multiple entities
+foreach (var p in products) p.Price *= 1.1m;
+_unitOfWork.Products.UpdateRange(products);
+await _unitOfWork.CommitAsync(userId: currentUserId);
+```
+
+---
+
+## Committing with a user ID
+
+Pass the authenticated user's ID so audit fields (`CreatedBy`, `ModifiedBy`) are populated automatically:
+
+```csharp
+await _unitOfWork.CommitAsync(userId: currentUserId);
+```
+
+If no `userId` is passed, `DefaultUserKey` (defined in your `UnitOfWork` implementation) is used instead.
+
+---
+
+## Custom repository methods
+
+Encapsulate domain-specific queries inside the repository, reusing the built-in helpers:
+
+```csharp
+public interface IProductRepository : IRepository<Product, long>
+{
+    Task<IEnumerable<Product>> GetActiveByCategoryAsync(long categoryId);
+    Task<bool> SkuExistsAsync(string sku);
+}
+
+public class ProductRepository : BaseRepository<Product, long>, IProductRepository
+{
+    public ProductRepository(DbContext context) : base(context) { }
+
+    public async Task<IEnumerable<Product>> GetActiveByCategoryAsync(long categoryId)
+        => await GetAllAsync(
+            condition: p => p.IsActive && p.CategoryId == categoryId,
+            orderBy: q => q.OrderBy(p => p.Name),
+            track: false);
+
+    public async Task<bool> SkuExistsAsync(string sku)
+        => await AnyAsync(p => p.Sku == sku);
+}
+```

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -91,7 +91,7 @@ int count = await _unitOfWork.Products.CountAsync(p => p.IsActive);
 
 ### Common optional parameters
 
-All query methods share these optional parameters:
+#### `Get*` methods (`GetById`, `GetAll`, `GetAllPaged`, `GetFirst`, `GetFirstOrDefault`, `GetSingle`, `GetSingleOrDefault`)
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
@@ -101,6 +101,14 @@ All query methods share these optional parameters:
 | `track` | `bool` | `true` | EF change tracking (set `false` for read-only queries) |
 | `ignoreQueryFilters` | `bool` | `false` | Bypass global EF query filters |
 | `useSplitQueries` | `bool` | `false` | Use [EF split queries](https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries) for includes |
+
+#### `Any` / `AnyAsync`
+
+Only accepts a required `condition` predicate (and `cancellationToken` for the async variant). `orderBy`, `include`, `track`, `ignoreQueryFilters`, and `useSplitQueries` are **not** supported.
+
+#### `Count` / `CountAsync`
+
+Accepts an optional `condition` predicate and `ignoreQueryFilters`. `orderBy`, `include`, `track`, and `useSplitQueries` are **not** supported.
 
 ### Selector overloads
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,141 @@
+# API Reference
+
+---
+
+## Read methods — `IReadOnlyRepository<TEntity, TKey>`
+
+### GetById
+
+Returns the entity with the given primary key, or `null` if not found.
+
+```csharp
+Product? product = await _unitOfWork.Products.GetByIdAsync(id);
+
+// With eager-loading
+Product? product = await _unitOfWork.Products.GetByIdAsync(id,
+    include: q => q.Include(p => p.Category));
+
+// Projected to a DTO
+string? name = await _unitOfWork.Products.GetByIdAsync(id,
+    selector: p => p.Name);
+```
+
+### GetAll
+
+Returns all entities matching the optional condition.
+
+```csharp
+IEnumerable<Product> all = await _unitOfWork.Products.GetAllAsync();
+
+IEnumerable<Product> active = await _unitOfWork.Products.GetAllAsync(
+    condition: p => p.IsActive,
+    orderBy: q => q.OrderBy(p => p.Name));
+```
+
+### GetAllPaged
+
+Returns a `Paged<TEntity>` (or `Paged<TResult>` with a selector). Page index is 1-based.
+
+```csharp
+Paged<Product> page = await _unitOfWork.Products.GetAllPagedAsync(
+    condition: p => p.IsActive,
+    orderBy: q => q.OrderBy(p => p.Name),
+    pageIndex: 1,
+    pageSize: 20);
+```
+
+| `Paged<T>` property | Description |
+|---|---|
+| `Results` | Items on the current page |
+| `TotalCount` | Total matching records |
+| `Page` | Current page index |
+| `PageSize` | Items per page |
+| `TotalPages` | Total number of pages |
+| `HasNext` | Whether a next page exists |
+| `HasPrevious` | Whether a previous page exists |
+
+### GetFirst / GetFirstOrDefault
+
+`GetFirst` throws if no match is found. `GetFirstOrDefault` returns `null`.
+
+```csharp
+Product first = await _unitOfWork.Products.GetFirstAsync(
+    condition: p => p.Price > 10m,
+    orderBy: q => q.OrderBy(p => p.Price));
+
+Product? firstOrNull = await _unitOfWork.Products.GetFirstOrDefaultAsync(
+    condition: p => p.Price > 10m);
+```
+
+### GetSingle / GetSingleOrDefault
+
+`GetSingle` throws if zero or more than one match is found. `GetSingleOrDefault` returns `null` when no match is found.
+
+```csharp
+Product single = await _unitOfWork.Products.GetSingleAsync(
+    condition: p => p.Sku == "ABC-123");
+
+Product? singleOrNull = await _unitOfWork.Products.GetSingleOrDefaultAsync(
+    condition: p => p.Sku == "ABC-123");
+```
+
+### Any / Count
+
+```csharp
+bool exists = await _unitOfWork.Products.AnyAsync(p => p.Sku == "ABC-123");
+
+int count = await _unitOfWork.Products.CountAsync(p => p.IsActive);
+```
+
+---
+
+### Common optional parameters
+
+All query methods share these optional parameters:
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `condition` | `Expression<Func<TEntity, bool>>?` | `null` | Filter predicate |
+| `orderBy` | `Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>?` | `null` | Sort function |
+| `include` | `Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>?` | `null` | Eager-load navigation properties |
+| `track` | `bool` | `true` | EF change tracking (set `false` for read-only queries) |
+| `ignoreQueryFilters` | `bool` | `false` | Bypass global EF query filters |
+| `useSplitQueries` | `bool` | `false` | Use [EF split queries](https://learn.microsoft.com/en-us/ef/core/querying/single-split-queries) for includes |
+
+### Selector overloads
+
+Every `GetAll`, `GetFirst`, `GetSingle`, and `GetById` method has a `selector` overload that projects the result without loading the full entity:
+
+```csharp
+// Returns IEnumerable<string> instead of IEnumerable<Product>
+IEnumerable<string> names = await _unitOfWork.Products.GetAllAsync(
+    selector: p => p.Name,
+    condition: p => p.IsActive);
+```
+
+---
+
+## Write methods — `IWriteRepository<TEntity, TKey>`
+
+| Method | Description |
+|---|---|
+| `Add(entity)` | Stages a single entity for insert |
+| `AddRange(entities)` | Stages multiple entities for insert |
+| `AddAsync(entity)` | Async version of `Add` |
+| `AddAsync(entities)` | Async version of `AddRange` |
+| `Update(entity)` | Marks a single entity as modified |
+| `UpdateRange(entities)` | Marks multiple entities as modified |
+| `Delete(entity)` | Marks a single entity for removal |
+| `DeleteById(id)` | Marks the entity with the given key for removal |
+| `DeleteRange(entities)` | Marks multiple entities for removal |
+
+> All write methods only stage changes in the EF change tracker. Call `CommitAsync()` or `Commit()` on the Unit of Work to persist them. See [Unit of Work](unit-of-work.md).
+
+---
+
+## Unit of Work — `IUnitOfWork<TUserKey>`
+
+| Method | Description |
+|---|---|
+| `CommitAsync(userId?, cancellationToken)` | Persists all staged changes and sets audit fields |
+| `Commit(userId?)` | Synchronous version of `CommitAsync` |

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -40,7 +40,7 @@ public class Product : BaseAuditableEntity<long>
 
 ## `BaseAuditableEntity<TId, TUserKey>`
 
-Extends `BaseAuditableEntity<TId>` and additionally tracks which user performed each operation. Both `TId` and `TUserKey` must be value types.
+Inherits directly from `BaseEntity<TId>` and implements `IAuditableEntity<TUserKey>` to track which user performed each operation. Both `TId` and `TUserKey` must be value types. Note: this variant does **not** include a `DeletedAt` property — see [Soft Delete](#soft-delete-ideletableentity) below.
 
 | Property | Type | Set on |
 |---|---|---|
@@ -70,10 +70,12 @@ public class Product : BaseAuditableEntity<long>, IDeletableEntity
 }
 
 // With user tracking
+// BaseAuditableEntity<TId, TUserKey> has no DeletedAt, so both interface members must be declared.
 public class Product : BaseAuditableEntity<long, Guid>, IDeletableEntity<Guid>
 {
     public string Name { get; set; } = string.Empty;
-    public Guid? DeletedBy { get; set; }
+    public DateTime? DeletedAt { get; set; }  // required by IDeletableEntity
+    public Guid? DeletedBy { get; set; }       // required by IDeletableEntity<Guid>
 }
 ```
 

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -1,0 +1,91 @@
+# Entities
+
+All entities used with RapidRepo must inherit from one of the provided base classes.
+
+---
+
+## `BaseEntity<TKey>`
+
+The simplest base class. Provides only an `Id` property. `TKey` must be a value type (e.g. `int`, `long`, `Guid`).
+
+```csharp
+public class Product : BaseEntity<long>
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public decimal Price { get; set; }
+}
+```
+
+---
+
+## `BaseAuditableEntity<TId>`
+
+Extends `BaseEntity<TId>` with timestamp-only audit fields. The Unit of Work automatically sets these on `Commit`/`CommitAsync`.
+
+| Property | Type | Set on |
+|---|---|---|
+| `CreatedAt` | `DateTime` | Insert |
+| `ModifiedAt` | `DateTime?` | Update |
+| `DeletedAt` | `DateTime?` | Soft delete |
+
+```csharp
+public class Product : BaseAuditableEntity<long>
+{
+    public string Name { get; set; } = string.Empty;
+}
+```
+
+---
+
+## `BaseAuditableEntity<TId, TUserKey>`
+
+Extends `BaseAuditableEntity<TId>` and additionally tracks which user performed each operation. Both `TId` and `TUserKey` must be value types.
+
+| Property | Type | Set on |
+|---|---|---|
+| `CreatedAt` | `DateTime` | Insert |
+| `CreatedBy` | `TUserKey` | Insert |
+| `ModifiedAt` | `DateTime?` | Update |
+| `ModifiedBy` | `TUserKey?` | Update |
+
+```csharp
+public class Product : BaseAuditableEntity<long, Guid>
+{
+    public string Name { get; set; } = string.Empty;
+}
+```
+
+---
+
+## Soft Delete (`IDeletableEntity`)
+
+Implement `IDeletableEntity` or `IDeletableEntity<TUserKey>` on any entity to enable soft delete. The `DeletedAt` (and optionally `DeletedBy`) fields are set automatically by the Unit of Work when the entity is deleted.
+
+```csharp
+// Timestamp only
+public class Product : BaseAuditableEntity<long>, IDeletableEntity
+{
+    public string Name { get; set; } = string.Empty;
+}
+
+// With user tracking
+public class Product : BaseAuditableEntity<long, Guid>, IDeletableEntity<Guid>
+{
+    public string Name { get; set; } = string.Empty;
+    public Guid? DeletedBy { get; set; }
+}
+```
+
+> To hide soft-deleted records automatically, configure a global EF Core query filter on `DeletedAt == null` in your `DbContext`. Use `ignoreQueryFilters: true` on any query to bypass it.
+
+---
+
+## Choosing the right base class
+
+| Scenario | Base class |
+|---|---|
+| No audit requirements | `BaseEntity<TId>` |
+| Track created/modified timestamps | `BaseAuditableEntity<TId>` |
+| Track who created/modified the record | `BaseAuditableEntity<TId, TUserKey>` |
+| Add soft delete to any of the above | Add `IDeletableEntity` or `IDeletableEntity<TUserKey>` |

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -83,7 +83,7 @@ public class ProductWriteRepository : WriteRepository<Product, long>, IProductWr
 
 ## Adding custom methods
 
-You can call any of the inherited `protected` query helpers directly from within your repository implementation, keeping the custom logic inside the data layer:
+You can call any of the inherited query methods/helpers directly from within your repository implementation, keeping the custom logic inside the data layer:
 
 ```csharp
 public interface IProductRepository : IRepository<Product, long>

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -1,0 +1,119 @@
+# Repositories
+
+---
+
+## Choosing an interface
+
+Pick the interface that matches the access pattern you need:
+
+| Interface | Extends | Purpose |
+|---|---|---|
+| `IRepository<TEntity, TKey>` | `IReadOnlyRepository` + `IWriteRepository` | Full CRUD |
+| `IReadOnlyRepository<TEntity, TKey>` | — | Queries only |
+| `IWriteRepository<TEntity, TKey>` | — | Writes only |
+
+```csharp
+// Full CRUD
+public interface IProductRepository : IRepository<Product, long>
+{
+    // Add custom methods here
+}
+
+// Read-only (e.g. for a reporting service)
+public interface IProductReadRepository : IReadOnlyRepository<Product, long>
+{
+}
+
+// Write-only (e.g. for an import pipeline)
+public interface IProductWriteRepository : IWriteRepository<Product, long>
+{
+}
+```
+
+---
+
+## Choosing a base class
+
+Pick the implementation base class that matches your interface:
+
+| Base class | Use with |
+|---|---|
+| `BaseRepository<TEntity, TKey>` | `IRepository<TEntity, TKey>` |
+| `ReadOnlyRepository<TEntity, TKey>` | `IReadOnlyRepository<TEntity, TKey>` |
+| `WriteRepository<TEntity, TKey>` | `IWriteRepository<TEntity, TKey>` |
+
+---
+
+## Implementation examples
+
+### Full CRUD repository
+
+```csharp
+public class ProductRepository : BaseRepository<Product, long>, IProductRepository
+{
+    public ProductRepository(DbContext context) : base(context)
+    {
+    }
+}
+```
+
+### Read-only repository
+
+```csharp
+public class ProductReadRepository : ReadOnlyRepository<Product, long>, IProductReadRepository
+{
+    public ProductReadRepository(DbContext context) : base(context)
+    {
+    }
+}
+```
+
+### Write-only repository
+
+```csharp
+public class ProductWriteRepository : WriteRepository<Product, long>, IProductWriteRepository
+{
+    public ProductWriteRepository(DbContext context) : base(context)
+    {
+    }
+}
+```
+
+---
+
+## Adding custom methods
+
+You can call any of the inherited `protected` query helpers directly from within your repository implementation, keeping the custom logic inside the data layer:
+
+```csharp
+public interface IProductRepository : IRepository<Product, long>
+{
+    Task<IEnumerable<Product>> GetByCategoryAsync(long categoryId);
+    Task<bool> ExistsByNameAsync(string name);
+}
+
+public class ProductRepository : BaseRepository<Product, long>, IProductRepository
+{
+    public ProductRepository(DbContext context) : base(context) { }
+
+    public async Task<IEnumerable<Product>> GetByCategoryAsync(long categoryId)
+        => await GetAllAsync(
+            condition: p => p.CategoryId == categoryId,
+            orderBy: q => q.OrderBy(p => p.Name));
+
+    public async Task<bool> ExistsByNameAsync(string name)
+        => await AnyAsync(p => p.Name == name);
+}
+```
+
+---
+
+## DI registration
+
+Register each repository with a scoped lifetime, matching the `DbContext` scope:
+
+```csharp
+builder.Services.AddScoped<IProductRepository, ProductRepository>();
+```
+
+See [Unit of Work](unit-of-work.md) for how to wire everything together.

--- a/docs/unit-of-work.md
+++ b/docs/unit-of-work.md
@@ -1,0 +1,90 @@
+# Unit of Work
+
+The Unit of Work groups one or more repositories under a single `DbContext`, coordinates commits, and automatically applies audit fields.
+
+---
+
+## Define the interface
+
+```csharp
+public interface IAppUnitOfWork : IUnitOfWork<Guid>, IDisposable
+{
+    IProductRepository Products { get; }
+}
+```
+
+---
+
+## Implement the class
+
+Inherit from `UnitOfWork<TUserKey>` and override `DefaultUserKey`. This value is used for audit fields when no `userId` is passed to `Commit`/`CommitAsync`.
+
+```csharp
+public class AppUnitOfWork : UnitOfWork<Guid>, IAppUnitOfWork
+{
+    public IProductRepository Products { get; }
+
+    public override Guid DefaultUserKey => Guid.Empty;
+
+    public AppUnitOfWork(
+        AppDbContext dbContext,
+        IProductRepository productRepository)
+        : base(dbContext)
+    {
+        Products = productRepository ?? throw new ArgumentNullException(nameof(productRepository));
+    }
+}
+```
+
+---
+
+## DI registration
+
+Register the `DbContext`, all repositories, and the Unit of Work with a scoped lifetime:
+
+```csharp
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("Default")));
+
+builder.Services.AddScoped<IProductRepository, ProductRepository>();
+builder.Services.AddScoped<IAppUnitOfWork, AppUnitOfWork>();
+```
+
+---
+
+## Committing changes
+
+Stage changes via repository methods, then persist them in a single call:
+
+```csharp
+// Async (preferred)
+await _unitOfWork.CommitAsync();
+
+// Sync
+_unitOfWork.Commit();
+```
+
+### Passing a user ID for auditing
+
+Pass the current user's ID to override `DefaultUserKey` for `CreatedBy`/`ModifiedBy`:
+
+```csharp
+await _unitOfWork.CommitAsync(userId: currentUserId);
+```
+
+---
+
+## How auditing works
+
+When `Commit`/`CommitAsync` is called, the Unit of Work inspects the EF change tracker and:
+
+| Entity state | Action |
+|---|---|
+| `Added` + `IAuditableEntity` | Sets `CreatedAt = UtcNow` |
+| `Added` + `IAuditableEntity<TUserKey>` | Sets `CreatedAt = UtcNow`, `CreatedBy = userId ?? DefaultUserKey` |
+| `Modified` + `IAuditableEntity` | Sets `ModifiedAt = UtcNow` |
+| `Modified` + `IAuditableEntity<TUserKey>` | Sets `ModifiedAt = UtcNow`, `ModifiedBy = userId ?? DefaultUserKey` |
+| `IDeletableEntity` with `DeletedAt != null` | Sets `DeletedAt = UtcNow` |
+| `IDeletableEntity<TUserKey>` with `DeletedAt != null` | Sets `DeletedAt = UtcNow`, `DeletedBy = userId ?? DefaultUserKey` |
+
+No manual timestamp management is needed in your application code.


### PR DESCRIPTION
- Rewrite README.md for clarity, brevity, and modern usage
- Add new docs: entities.md, repositories.md, unit-of-work.md, api-reference.md, advanced.md
- Organize documentation by topic with tables and code samples
- Emphasize best practices: DI, auditing, soft delete, paging, projection
- README now links to detailed topic docs for easy navigation
- Improve overall tone and focus on real-world .NET usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Condensed README and added clear Requirements, Installation, and Quick Start sections with a trimmed feature summary.
  * Added five in-depth docs covering advanced usage, API reference, entity base types, repository patterns, and unit-of-work guidance.
  * Expanded guidance on query options, paging semantics, audit-field automation, soft-delete behavior, and dependency-injection registration recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->