### PR TITLE
chore(workflow): Add explicit read-only permissions to publish-nuget.yml

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published, prereleased]
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Set permissions: contents: read in the publish-nuget.yml workflow to grant only the minimum required access. This follows GitHub Actions best practices for security by limiting workflow permissions. No other workflow logic was changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions configuration to enforce read-only access to repository contents during automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->