### PR TITLE
feat(entities): support non-null entity keys (including string)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ RapidRepo is a repository pattern implementation for .NET applications. It uses 
 - EF Core-based data access
 - Consistent and reusable CRUD patterns
 - Separation of business logic and persistence logic
+- Supports non-null entity key types (e.g. `int`, `Guid`, `string`)
 - Built-in auditing (`CreatedAt`, `CreatedBy`, `ModifiedAt`, `ModifiedBy`)
 - Built-in soft delete support (`DeletedAt`, `DeletedBy`)
 - Paged query results via `Paged<T>`

--- a/RapidRepo.Tests/Repositories/BaseRepository/AddAsyncTests.cs
+++ b/RapidRepo.Tests/Repositories/BaseRepository/AddAsyncTests.cs
@@ -44,7 +44,7 @@ public class AddAsyncTests : BaseWriteRepositoryTest
         }
 
         // Act
-        await _sut.AddAsync(employees);
+        await _sut.AddRangeAsync(employees);
         await _dbContext.SaveChangesAsync();
 
         // Assert

--- a/RapidRepo.Tests/Repositories/BaseRepository/AddTests.cs
+++ b/RapidRepo.Tests/Repositories/BaseRepository/AddTests.cs
@@ -53,4 +53,14 @@ public class AddTests : BaseWriteRepositoryTest
         _dbContext.Employees.Count().Should().Be(numberOfEmployeesToAdd);
         _dbContext.Employees.Select(e => e.Id).Should().OnlyHaveUniqueItems();
     }
+
+    [Fact]
+    public void Add_ShouldThrowArgumentNullException_WhenEntityIsNull()
+    {
+        // Act
+        Action act = () => _sut.Add(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
 }

--- a/RapidRepo.Tests/Repositories/BaseRepository/AnyAsyncTests.cs
+++ b/RapidRepo.Tests/Repositories/BaseRepository/AnyAsyncTests.cs
@@ -45,4 +45,12 @@ public class AnyAsyncTests : BaseWriteRepositoryTest
         // Assert
         result.Should().BeFalse();
     }
+
+    [Fact]
+    public async Task AnyAsync_ShouldThrowArgumentNullException_WhenConditionIsNull()
+    {
+        var act = async () => await _sut.AnyAsync(null!);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
 }

--- a/RapidRepo.Tests/Repositories/BaseRepository/AnyTests.cs
+++ b/RapidRepo.Tests/Repositories/BaseRepository/AnyTests.cs
@@ -45,4 +45,12 @@ public class AnyTests : BaseWriteRepositoryTest
         // Assert
         result.Should().BeFalse();
     }
+
+    [Fact]
+    public void Any_ShouldThrowArgumentNullException_WhenConditionIsNull()
+    {
+        Action act = () => _sut.Any(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
 }

--- a/RapidRepo.Tests/Repositories/BaseRepository/DeleteByIdTests.cs
+++ b/RapidRepo.Tests/Repositories/BaseRepository/DeleteByIdTests.cs
@@ -1,4 +1,5 @@
-﻿using RapidRepo.Tests.Repositories.TestData;
+﻿using RapidRepo.Tests.Repositories.BaseRepository.TestData;
+using RapidRepo.Tests.Repositories.TestData;
 
 namespace RapidRepo.Tests.Repositories.BaseRepository;
 public class DeleteByIdTests : BaseWriteRepositoryTest
@@ -37,5 +38,29 @@ public class DeleteByIdTests : BaseWriteRepositoryTest
 
         // Assert
         Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task DeleteById_ShouldDeleteEntity_WhenStringKeyIsUsed()
+    {
+        // Arrange
+        var repository = new AccessTokenRepository(_dbContext);
+        var token = new AccessToken
+        {
+            Id = "token-1",
+            Value = "abc123"
+        };
+
+        _dbContext.AccessTokens.Add(token);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        repository.DeleteById(token.Id);
+        await _dbContext.SaveChangesAsync();
+        DetachAllEntities();
+
+        // Assert
+        var deletedToken = await _dbContext.AccessTokens.FindAsync(token.Id);
+        Assert.Null(deletedToken);
     }
 }

--- a/RapidRepo.Tests/Repositories/BaseRepository/GetAllSelectorTests.cs
+++ b/RapidRepo.Tests/Repositories/BaseRepository/GetAllSelectorTests.cs
@@ -44,4 +44,16 @@ public class GetAllSelectorTests : BaseWriteRepositoryTest
         Assert.Contains(result, e => e.Id == 1 && e.FirstName == "John" && e.LastName == "Doe");
         Assert.Contains(result, e => e.Id == 2 && e.FirstName == "Jane" && e.LastName == "Smith");
     }
+
+    [Fact]
+    public void GetAll_WithSelector_ShouldThrowArgumentNullException_WhenSelectorIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => _sut.GetAll<string>(selector: null!).ToList());
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WithSelector_ShouldThrowArgumentNullException_WhenSelectorIsNull()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _sut.GetAllAsync<string>(selector: null!));
+    }
 }

--- a/RapidRepo.Tests/Repositories/BaseRepository/GetByIdAsyncTests.cs
+++ b/RapidRepo.Tests/Repositories/BaseRepository/GetByIdAsyncTests.cs
@@ -95,4 +95,12 @@ public class GetByIdAsyncTests : BaseWriteRepositoryTest
         // Assert
         result.Should().BeEquivalentTo(new { FirstName = fistNameExpected, LastName = lastNameExpected });
     }
+
+    [Fact]
+    public async Task GetByIdAsyncSelector_ShouldThrowArgumentNullException_WhenSelectorIsNull()
+    {
+        var act = async () => await _sut.GetByIdAsync<string>(id: 1, selector: null!);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
 }

--- a/RapidRepo.Tests/Repositories/BaseRepository/GetByIdTests.cs
+++ b/RapidRepo.Tests/Repositories/BaseRepository/GetByIdTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using RapidRepo.Tests.Repositories.BaseRepository.TestData;
 using RapidRepo.Tests.Repositories.TestData;
 
 namespace RapidRepo.Tests.Repositories.BaseRepository;
@@ -94,5 +95,27 @@ public class GetByIdTests : BaseWriteRepositoryTest
 
         // Assert
         result.Should().Be(new { FirstName = fistNameExpected, LastName = lastNameExpected });
+    }
+
+    [Fact]
+    public void GetById_ShouldReturnEntity_WhenStringKeyIsUsed()
+    {
+        // Arrange
+        var repository = new AccessTokenRepository(_dbContext);
+        var token = new AccessToken
+        {
+            Id = "token-1",
+            Value = "abc123"
+        };
+
+        _dbContext.AccessTokens.Add(token);
+        _dbContext.SaveChanges();
+        DetachAllEntities();
+
+        // Act
+        var result = repository.GetById(token.Id);
+
+        // Assert
+        result.Should().BeEquivalentTo(token);
     }
 }

--- a/RapidRepo.Tests/Repositories/BaseRepository/GetByIdTests.cs
+++ b/RapidRepo.Tests/Repositories/BaseRepository/GetByIdTests.cs
@@ -118,4 +118,12 @@ public class GetByIdTests : BaseWriteRepositoryTest
         // Assert
         result.Should().BeEquivalentTo(token);
     }
+
+    [Fact]
+    public void GetByIdSelector_ShouldThrowArgumentNullException_WhenSelectorIsNull()
+    {
+        Action act = () => _sut.GetById<string>(id: 1, selector: null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
 }

--- a/RapidRepo.Tests/Repositories/BaseRepository/TestData/AccessTokenRepository.cs
+++ b/RapidRepo.Tests/Repositories/BaseRepository/TestData/AccessTokenRepository.cs
@@ -1,0 +1,12 @@
+using RapidRepo.Repositories;
+using RapidRepo.Tests.Repositories.TestData;
+
+namespace RapidRepo.Tests.Repositories.BaseRepository.TestData;
+
+public class AccessTokenRepository : BaseRepository<AccessToken, string>
+{
+    public AccessTokenRepository(TestDbContext dbContext)
+        : base(dbContext)
+    {
+    }
+}

--- a/RapidRepo.Tests/Repositories/BaseRepository/UpdateTests.cs
+++ b/RapidRepo.Tests/Repositories/BaseRepository/UpdateTests.cs
@@ -30,4 +30,14 @@ public class UpdateTests : BaseWriteRepositoryTest
         updatedEmployee.Should().BeEquivalentTo(employee);
         updatedEmployee!.FirstName.Should().Be("Updated Name");
     }
+
+    [Fact]
+    public void Update_ShouldThrowArgumentNullException_WhenEntityIsNull()
+    {
+        // Act
+        Action act = () => _sut.Update(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
 }

--- a/RapidRepo.Tests/Repositories/ReadOnlyRepository/AnyAsyncTests.cs
+++ b/RapidRepo.Tests/Repositories/ReadOnlyRepository/AnyAsyncTests.cs
@@ -45,4 +45,12 @@ public class AnyAsyncTests : BaseReadOnlyRepositoryTest
         // Assert
         result.Should().BeFalse();
     }
+
+    [Fact]
+    public async Task AnyAsync_ShouldThrowArgumentNullException_WhenConditionIsNull()
+    {
+        var act = async () => await _sut.AnyAsync(null!);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
 }

--- a/RapidRepo.Tests/Repositories/ReadOnlyRepository/AnyTests.cs
+++ b/RapidRepo.Tests/Repositories/ReadOnlyRepository/AnyTests.cs
@@ -45,4 +45,12 @@ public class AnyTests : BaseReadOnlyRepositoryTest
         // Assert
         result.Should().BeFalse();
     }
+
+    [Fact]
+    public void Any_ShouldThrowArgumentNullException_WhenConditionIsNull()
+    {
+        Action act = () => _sut.Any(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
 }

--- a/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetAllAsyncSelectorTests.cs
+++ b/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetAllAsyncSelectorTests.cs
@@ -23,4 +23,10 @@ public class GetAllAsyncSelectorTests : BaseReadOnlyRepositoryTest
         Assert.Contains(result, e => e.Id == 1 && e.FirstName == "John" && e.LastName == "Doe");
         Assert.Contains(result, e => e.Id == 2 && e.FirstName == "Jane" && e.LastName == "Smith");
     }
+
+    [Fact]
+    public async Task GetAllAsync_WithSelector_ShouldThrowArgumentNullException_WhenSelectorIsNull()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _sut.GetAllAsync<string>(selector: null!));
+    }
 }

--- a/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetAllSelectorTests.cs
+++ b/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetAllSelectorTests.cs
@@ -44,4 +44,16 @@ public class GetAllSelectorTests : BaseReadOnlyRepositoryTest
         Assert.Contains(result, e => e.Id == 1 && e.FirstName == "John" && e.LastName == "Doe");
         Assert.Contains(result, e => e.Id == 2 && e.FirstName == "Jane" && e.LastName == "Smith");
     }
+
+    [Fact]
+    public void GetAll_WithSelector_ShouldThrowArgumentNullException_WhenSelectorIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => _sut.GetAll<string>(selector: null!).ToList());
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WithSelector_ShouldThrowArgumentNullException_WhenSelectorIsNull()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _sut.GetAllAsync<string>(selector: null!));
+    }
 }

--- a/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetByIdAsyncTests.cs
+++ b/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetByIdAsyncTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+using FluentAssertions;
+using RapidRepo.Tests.Repositories.ReadOnlyRepository.TestData;
 using RapidRepo.Tests.Repositories.TestData;
 
 namespace RapidRepo.Tests.Repositories.ReadOnlyRepository;
@@ -94,5 +95,83 @@ public class GetByIdAsyncTests : BaseReadOnlyRepositoryTest
 
         // Assert
         result.Should().BeEquivalentTo(new { FirstName = fistNameExpected, LastName = lastNameExpected });
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ShouldReturnEntity_WhenStringKeyIsUsed()
+    {
+        // Arrange
+        var repository = new ReadOnlyAccessTokenRepository(_dbContext);
+        var token = new AccessToken
+        {
+            Id = "token-async-1",
+            Value = "abc123"
+        };
+
+        _dbContext.AccessTokens.Add(token);
+        await _dbContext.SaveChangesAsync();
+        DetachAllEntities();
+
+        // Act
+        var result = await repository.GetByIdAsync(token.Id);
+
+        // Assert
+        result.Should().BeEquivalentTo(token);
+    }
+
+    [Fact]
+    public async Task GetByIdAsyncSelector_ShouldReturnValue_WhenStringKeyIsUsed()
+    {
+        // Arrange
+        var repository = new ReadOnlyAccessTokenRepository(_dbContext);
+        var token = new AccessToken
+        {
+            Id = "token-async-2",
+            Value = "xyz789"
+        };
+
+        _dbContext.AccessTokens.Add(token);
+        await _dbContext.SaveChangesAsync();
+        DetachAllEntities();
+
+        // Act
+        var result = await repository.GetByIdAsync(id: token.Id, selector: t => t.Value);
+
+        // Assert
+        result.Should().Be(token.Value);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ShouldThrowArgumentNullException_WhenIdIsNull()
+    {
+        // Arrange
+        var repository = new ReadOnlyAccessTokenRepository(_dbContext);
+
+        // Act
+        var act = async () => await repository.GetByIdAsync(null!);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task GetByIdAsyncSelector_ShouldThrowArgumentNullException_WhenIdIsNull()
+    {
+        // Arrange
+        var repository = new ReadOnlyAccessTokenRepository(_dbContext);
+
+        // Act
+        var act = async () => await repository.GetByIdAsync(id: null!, selector: t => t.Value);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task GetByIdAsyncSelector_ShouldThrowArgumentNullException_WhenSelectorIsNull()
+    {
+        var act = async () => await _sut.GetByIdAsync<string>(id: 1, selector: null!);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
     }
 }

--- a/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetByIdTests.cs
+++ b/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetByIdTests.cs
@@ -118,4 +118,25 @@ public class GetByIdTests : BaseReadOnlyRepositoryTest
         // Assert
         result.Should().BeEquivalentTo(token);
     }
+
+    [Fact]
+    public void GetById_ShouldThrowArgumentNullException_WhenIdIsNull()
+    {
+        // Arrange
+        var repository = new ReadOnlyAccessTokenRepository(_dbContext);
+
+        // Act
+        Action act = () => repository.GetById(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GetByIdSelector_ShouldThrowArgumentNullException_WhenSelectorIsNull()
+    {
+        Action act = () => _sut.GetById<string>(id: 1, selector: null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
 }

--- a/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetByIdTests.cs
+++ b/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetByIdTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using RapidRepo.Tests.Repositories.ReadOnlyRepository.TestData;
 using RapidRepo.Tests.Repositories.TestData;
 
 namespace RapidRepo.Tests.Repositories.ReadOnlyRepository;
@@ -94,5 +95,27 @@ public class GetByIdTests : BaseReadOnlyRepositoryTest
 
         // Assert
         result.Should().Be(new { FirstName = fistNameExpected, LastName = lastNameExpected });
+    }
+
+    [Fact]
+    public void GetById_ShouldReturnEntity_WhenStringKeyIsUsed()
+    {
+        // Arrange
+        var repository = new ReadOnlyAccessTokenRepository(_dbContext);
+        var token = new AccessToken
+        {
+            Id = "token-1",
+            Value = "abc123"
+        };
+
+        _dbContext.AccessTokens.Add(token);
+        _dbContext.SaveChanges();
+        DetachAllEntities();
+
+        // Act
+        var result = repository.GetById(token.Id);
+
+        // Assert
+        result.Should().BeEquivalentTo(token);
     }
 }

--- a/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetFirstAsyncSelectorTests.cs
+++ b/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetFirstAsyncSelectorTests.cs
@@ -33,4 +33,10 @@ public class GetFirstAsyncSelectorTests : BaseReadOnlyRepositoryTest
         // Assert
         result.Should().BeEquivalentTo(new { employee1.FirstName, employee1.LastName });
     }
+
+    [Fact]
+    public async Task GetFirstAsync_WithSelector_ShouldThrowArgumentNullException_WhenSelectorIsNull()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _sut.GetFirstAsync<string>(selector: null!));
+    }
 }

--- a/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetFirstOrDefaultAsyncSelectorTests.cs
+++ b/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetFirstOrDefaultAsyncSelectorTests.cs
@@ -63,4 +63,10 @@ public class GetFirstOrDefaultAsyncSelectorTests : BaseReadOnlyRepositoryTest
         // Assert
         result.Should().BeNull();
     }
+
+    [Fact]
+    public async Task GetFirstOrDefaultAsync_WithSelector_ShouldThrowArgumentNullException_WhenSelectorIsNull()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _sut.GetFirstOrDefaultAsync<string>(selector: null!));
+    }
 }

--- a/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetFirstOrDefaultSelectorTests.cs
+++ b/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetFirstOrDefaultSelectorTests.cs
@@ -63,4 +63,14 @@ public class GetFirstOrDefaultSelectorTests : BaseReadOnlyRepositoryTest
         // Assert
         result.Should().BeNull();
     }
+
+    [Fact]
+    public void GetFirstOrDefault_WithSelector_ShouldThrowArgumentNullException_WhenSelectorIsNull()
+    {
+        // Act
+        Action act = () => _sut.GetFirstOrDefault<string>(selector: null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
 }

--- a/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetFirstSelectorTests.cs
+++ b/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetFirstSelectorTests.cs
@@ -33,4 +33,10 @@ public class GetFirstSelectorTests : BaseReadOnlyRepositoryTest
         // Assert
         result.Should().BeEquivalentTo(new { employee1.FirstName, employee1.LastName });
     }
+
+    [Fact]
+    public void GetFirst_WithSelector_ShouldThrowArgumentNullException_WhenSelectorIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => _sut.GetFirst<string>(selector: null!));
+    }
 }

--- a/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetSingleAsyncSelectorTests.cs
+++ b/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetSingleAsyncSelectorTests.cs
@@ -33,4 +33,10 @@ public class GetSingleAsyncSelectorTests : BaseReadOnlyRepositoryTest
         // Assert
         result.Should().BeEquivalentTo(new { employee1.FirstName, employee1.LastName });
     }
+
+    [Fact]
+    public async Task GetSingleAsync_WithSelector_ShouldThrowArgumentNullException_WhenSelectorIsNull()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _sut.GetSingleAsync<string>(selector: null!));
+    }
 }

--- a/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetSingleOrDefaultAsyncSelectorTests.cs
+++ b/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetSingleOrDefaultAsyncSelectorTests.cs
@@ -63,4 +63,10 @@ public class GetSingleOrDefaultAsyncSelectorTests : BaseReadOnlyRepositoryTest
         // Assert
         result.Should().BeNull();
     }
+
+    [Fact]
+    public async Task GetSingleOrDefaultAsync_WithSelector_ShouldThrowArgumentNullException_WhenSelectorIsNull()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _sut.GetSingleOrDefaultAsync<string>(selector: null!));
+    }
 }

--- a/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetSingleOrDefaultSelectorTests.cs
+++ b/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetSingleOrDefaultSelectorTests.cs
@@ -63,4 +63,11 @@ public class GetSingleOrDefaultSelectorTests : BaseReadOnlyRepositoryTest
         // Assert
         result.Should().BeNull();
     }
+
+    [Fact]
+    public void GetSingleOrDefault_WithSelector_ShouldThrowArgumentNullException_WhenSelectorIsNull()
+    {
+        // Act
+        Assert.Throws<ArgumentNullException>(() => _sut.GetSingleOrDefault<string>(selector: null!));
+    }
 }

--- a/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetSingleSelectorTests.cs
+++ b/RapidRepo.Tests/Repositories/ReadOnlyRepository/GetSingleSelectorTests.cs
@@ -33,4 +33,14 @@ public class GetSingleSelectorTests : BaseReadOnlyRepositoryTest
         // Assert
         result.Should().BeEquivalentTo(new { employee1.FirstName, employee1.LastName });
     }
+
+    [Fact]
+    public void GetSingle_WithSelector_ShouldThrowArgumentNullException_WhenSelectorIsNull()
+    {
+        // Act
+        Action act = () => _sut.GetSingle<string>(selector: null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
 }

--- a/RapidRepo.Tests/Repositories/ReadOnlyRepository/TestData/ReadOnlyAccessTokenRepository.cs
+++ b/RapidRepo.Tests/Repositories/ReadOnlyRepository/TestData/ReadOnlyAccessTokenRepository.cs
@@ -1,0 +1,13 @@
+using Microsoft.EntityFrameworkCore;
+using RapidRepo.Repositories;
+using RapidRepo.Tests.Repositories.TestData;
+
+namespace RapidRepo.Tests.Repositories.ReadOnlyRepository.TestData;
+
+internal class ReadOnlyAccessTokenRepository : ReadOnlyRepository<AccessToken, string>
+{
+    public ReadOnlyAccessTokenRepository(DbContext dbContext)
+        : base(dbContext)
+    {
+    }
+}

--- a/RapidRepo.Tests/Repositories/TestData/AccessToken.cs
+++ b/RapidRepo.Tests/Repositories/TestData/AccessToken.cs
@@ -1,0 +1,8 @@
+using RapidRepo.Entities;
+
+namespace RapidRepo.Tests.Repositories.TestData;
+
+public class AccessToken : BaseEntity<string>
+{
+    public required string Value { get; set; }
+}

--- a/RapidRepo.Tests/Repositories/TestData/TestDbContext.cs
+++ b/RapidRepo.Tests/Repositories/TestData/TestDbContext.cs
@@ -19,6 +19,10 @@ public class TestDbContext : DbContext
     {
         modelBuilder.Entity<Employee>().HasQueryFilter(e => e.DeletedAt == null && e.DeletedBy == null);
         modelBuilder.Entity<Company>().HasQueryFilter(e => e.DeletedAt == null);
-        modelBuilder.Entity<AccessToken>().HasKey(e => e.Id);
+        modelBuilder.Entity<AccessToken>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).ValueGeneratedNever();
+        });
     }
 }

--- a/RapidRepo.Tests/Repositories/TestData/TestDbContext.cs
+++ b/RapidRepo.Tests/Repositories/TestData/TestDbContext.cs
@@ -6,6 +6,7 @@ public class TestDbContext : DbContext
 {
     internal DbSet<Employee> Employees { get; set; }
     internal DbSet<Company> Companies { get; set; }
+    internal DbSet<AccessToken> AccessTokens { get; set; }
 
     public TestDbContext(
         DbContextOptions<TestDbContext> options)
@@ -18,5 +19,6 @@ public class TestDbContext : DbContext
     {
         modelBuilder.Entity<Employee>().HasQueryFilter(e => e.DeletedAt == null && e.DeletedBy == null);
         modelBuilder.Entity<Company>().HasQueryFilter(e => e.DeletedAt == null);
+        modelBuilder.Entity<AccessToken>().HasKey(e => e.Id);
     }
 }

--- a/RapidRepo.Tests/Repositories/WriteRepository/AddAsyncTests.cs
+++ b/RapidRepo.Tests/Repositories/WriteRepository/AddAsyncTests.cs
@@ -44,7 +44,7 @@ public class AddAsyncTests : BaseWriteRepositoryTest
         }
 
         // Act
-        await _sut.AddAsync(employees);
+        await _sut.AddRangeAsync(employees);
         await _dbContext.SaveChangesAsync();
 
         // Assert
@@ -63,7 +63,7 @@ public class AddAsyncTests : BaseWriteRepositoryTest
     [Fact]
     public async Task AddAsync_ShouldThrowArgumentNullException_WhenEntitiesIsNull()
     {
-        var act = async () => await _sut.AddAsync((IEnumerable<Employee>)null!);
+        var act = async () => await _sut.AddRangeAsync((IEnumerable<Employee>)null!);
 
         await act.Should().ThrowAsync<ArgumentNullException>();
     }

--- a/RapidRepo.Tests/Repositories/WriteRepository/AddAsyncTests.cs
+++ b/RapidRepo.Tests/Repositories/WriteRepository/AddAsyncTests.cs
@@ -51,4 +51,20 @@ public class AddAsyncTests : BaseWriteRepositoryTest
         _dbContext.Employees.Count().Should().Be(numberOfEmployeesToAdd);
         _dbContext.Employees.Select(e => e.Id).Should().OnlyHaveUniqueItems();
     }
+
+    [Fact]
+    public async Task AddAsync_ShouldThrowArgumentNullException_WhenEntityIsNull()
+    {
+        var act = async () => await _sut.AddAsync((Employee)null!);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task AddAsync_ShouldThrowArgumentNullException_WhenEntitiesIsNull()
+    {
+        var act = async () => await _sut.AddAsync((IEnumerable<Employee>)null!);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
 }

--- a/RapidRepo.Tests/Repositories/WriteRepository/AddTests.cs
+++ b/RapidRepo.Tests/Repositories/WriteRepository/AddTests.cs
@@ -53,4 +53,24 @@ public class AddTests : BaseWriteRepositoryTest
         _dbContext.Employees.Count().Should().Be(numberOfEmployeesToAdd);
         _dbContext.Employees.Select(e => e.Id).Should().OnlyHaveUniqueItems();
     }
+
+    [Fact]
+    public void Add_ShouldThrowArgumentNullException_WhenEntityIsNull()
+    {
+        // Act
+        Action act = () => _sut.Add(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void AddRange_ShouldThrowArgumentNullException_WhenEntitiesIsNull()
+    {
+        // Act
+        Action act = () => _sut.AddRange(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
 }

--- a/RapidRepo.Tests/Repositories/WriteRepository/DeleteByIdTests.cs
+++ b/RapidRepo.Tests/Repositories/WriteRepository/DeleteByIdTests.cs
@@ -63,4 +63,12 @@ public class DeleteByIdTests : BaseWriteRepositoryTest
         var deletedToken = await _dbContext.AccessTokens.FindAsync(token.Id);
         Assert.Null(deletedToken);
     }
+
+    [Fact]
+    public void DeleteById_ShouldThrowArgumentNullException_WhenIdIsNull_ForStringKey()
+    {
+        var repository = new WriteAccessTokenRepository(_dbContext);
+
+        Assert.Throws<ArgumentNullException>(() => repository.DeleteById(null!));
+    }
 }

--- a/RapidRepo.Tests/Repositories/WriteRepository/DeleteByIdTests.cs
+++ b/RapidRepo.Tests/Repositories/WriteRepository/DeleteByIdTests.cs
@@ -1,4 +1,5 @@
 ﻿using RapidRepo.Tests.Repositories.TestData;
+using RapidRepo.Tests.Repositories.WriteRepository.TestData;
 
 namespace RapidRepo.Tests.Repositories.WriteRepository;
 public class DeleteByIdTests : BaseWriteRepositoryTest
@@ -37,5 +38,29 @@ public class DeleteByIdTests : BaseWriteRepositoryTest
 
         // Assert
         Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task DeleteById_ShouldDeleteEntity_WhenStringKeyIsUsed()
+    {
+        // Arrange
+        var repository = new WriteAccessTokenRepository(_dbContext);
+        var token = new AccessToken
+        {
+            Id = "token-1",
+            Value = "abc123"
+        };
+
+        _dbContext.AccessTokens.Add(token);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        repository.DeleteById(token.Id);
+        await _dbContext.SaveChangesAsync();
+        DetachAllEntities();
+
+        // Assert
+        var deletedToken = await _dbContext.AccessTokens.FindAsync(token.Id);
+        Assert.Null(deletedToken);
     }
 }

--- a/RapidRepo.Tests/Repositories/WriteRepository/DeleteRangeTests.cs
+++ b/RapidRepo.Tests/Repositories/WriteRepository/DeleteRangeTests.cs
@@ -101,4 +101,12 @@ public class DeleteRangeTests : BaseWriteRepositoryTest
         var remainingCompanies = _dbContext.Companies.ToList();
         Assert.Empty(remainingCompanies);
     }
+
+    [Fact]
+    public void DeleteRange_ShouldThrowArgumentNullException_WhenEntitiesIsNull()
+    {
+        Action act = () => _sut.DeleteRange(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
 }

--- a/RapidRepo.Tests/Repositories/WriteRepository/DeleteTests.cs
+++ b/RapidRepo.Tests/Repositories/WriteRepository/DeleteTests.cs
@@ -115,4 +115,12 @@ public class DeleteTests : BaseWriteRepositoryTest
         // Assert
         act.Should().NotThrow();
     }
+
+    [Fact]
+    public void Delete_ShouldThrowArgumentNullException_WhenEntityIsNull()
+    {
+        Action act = () => _sut.Delete(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
 }

--- a/RapidRepo.Tests/Repositories/WriteRepository/TestData/WriteAccessTokenRepository.cs
+++ b/RapidRepo.Tests/Repositories/WriteRepository/TestData/WriteAccessTokenRepository.cs
@@ -1,0 +1,13 @@
+using Microsoft.EntityFrameworkCore;
+using RapidRepo.Repositories;
+using RapidRepo.Tests.Repositories.TestData;
+
+namespace RapidRepo.Tests.Repositories.WriteRepository.TestData;
+
+internal class WriteAccessTokenRepository : WriteRepository<AccessToken, string>
+{
+    public WriteAccessTokenRepository(DbContext dbContext)
+        : base(dbContext)
+    {
+    }
+}

--- a/RapidRepo.Tests/Repositories/WriteRepository/UpdateRangeTests.cs
+++ b/RapidRepo.Tests/Repositories/WriteRepository/UpdateRangeTests.cs
@@ -55,4 +55,14 @@ public class UpdateRangeTests : BaseWriteRepositoryTest
                 opts => opts.WithoutStrictOrdering()
                     .ExcludingMissingMembers());
     }
+
+    [Fact]
+    public void UpdateRange_ShouldThrowArgumentNullException_WhenEntitiesIsNull()
+    {
+        // Act
+        Action act = () => _sut.UpdateRange(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
 }

--- a/RapidRepo.Tests/Repositories/WriteRepository/UpdateTests.cs
+++ b/RapidRepo.Tests/Repositories/WriteRepository/UpdateTests.cs
@@ -30,4 +30,14 @@ public class UpdateTests : BaseWriteRepositoryTest
         updatedEmployee.Should().BeEquivalentTo(employee);
         updatedEmployee!.FirstName.Should().Be("Updated Name");
     }
+
+    [Fact]
+    public void Update_ShouldThrowArgumentNullException_WhenEntityIsNull()
+    {
+        // Act
+        Action act = () => _sut.Update(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
 }

--- a/RapidRepo/Entities/BaseAuditableEntity.cs
+++ b/RapidRepo/Entities/BaseAuditableEntity.cs
@@ -1,7 +1,6 @@
-﻿using RapidRepo.Entities;
-using RapidRepo.Entities.Interfaces;
+﻿using RapidRepo.Entities.Interfaces;
 
-namespace Repository.Entities;
+namespace RapidRepo.Entities;
 
 /// <summary>
 /// Represents a base auditable entity with common audit fields.
@@ -9,7 +8,7 @@ namespace Repository.Entities;
 /// <typeparam name="TId">The type of the entity's identifier.</typeparam>
 /// <typeparam name="TUserKey">The type of the user identifier.</typeparam>
 public class BaseAuditableEntity<TId, TUserKey> : BaseEntity<TId>, IAuditableEntity<TUserKey>
-    where TId : struct
+    where TId : notnull
     where TUserKey : struct
 {
     /// <summary>
@@ -38,7 +37,7 @@ public class BaseAuditableEntity<TId, TUserKey> : BaseEntity<TId>, IAuditableEnt
 /// </summary>
 /// <typeparam name="TId">The type of the entity's identifier.</typeparam>
 public class BaseAuditableEntity<TId> : BaseEntity<TId>, IAuditableEntity
-    where TId : struct
+    where TId : notnull
 {
     /// <summary>
     /// Gets or sets the date and time when the entity was created.

--- a/RapidRepo/Entities/BaseEntity.cs
+++ b/RapidRepo/Entities/BaseEntity.cs
@@ -5,7 +5,7 @@
 /// </summary>
 /// <typeparam name="TId">The type of the ID.</typeparam>
 public abstract class BaseEntity<TId>
-    where TId : struct
+    where TId : notnull
 {
     /// <summary>
     /// Gets or sets the ID of the entity.

--- a/RapidRepo/Extensions/IQueryableExtensions.cs
+++ b/RapidRepo/Extensions/IQueryableExtensions.cs
@@ -15,7 +15,7 @@ internal static class IQueryableExtensions
         bool ignoreQueryFilters = false,
         bool track = true)
         where TEntity : BaseEntity<TId>
-        where TId : struct
+        where TId : notnull
     {
         if (!track)
         {

--- a/RapidRepo/Repositories/BaseRepository.cs
+++ b/RapidRepo/Repositories/BaseRepository.cs
@@ -24,8 +24,8 @@ public abstract class BaseRepository<TEntity, TId> : ReadOnlyRepository<TEntity,
     public virtual Task AddAsync(TEntity entity, CancellationToken cancellationToken = default) =>
         _writeRepository.AddAsync(entity, cancellationToken);
 
-    public virtual Task AddAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) =>
-        _writeRepository.AddAsync(entities, cancellationToken);
+    public virtual Task AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) =>
+        _writeRepository.AddRangeAsync(entities, cancellationToken);
 
     public virtual void Delete(TEntity entity) => _writeRepository.Delete(entity);
 

--- a/RapidRepo/Repositories/BaseRepository.cs
+++ b/RapidRepo/Repositories/BaseRepository.cs
@@ -6,7 +6,7 @@ namespace RapidRepo.Repositories;
 
 public abstract class BaseRepository<TEntity, TId> : ReadOnlyRepository<TEntity, TId>, IRepository<TEntity, TId>
     where TEntity : BaseEntity<TId>
-    where TId : struct
+    where TId : notnull
 {
     private readonly IWriteRepository<TEntity, TId> _writeRepository;
 

--- a/RapidRepo/Repositories/BaseWriteRepository.cs
+++ b/RapidRepo/Repositories/BaseWriteRepository.cs
@@ -15,6 +15,6 @@ namespace RapidRepo.Repositories;
 public sealed class BaseWriteRepository<TEntity, TId>(DbContext dbContext)
     : WriteRepository<TEntity, TId>(dbContext)
     where TEntity : BaseEntity<TId>
-    where TId : struct
+    where TId : notnull
 {
 }

--- a/RapidRepo/Repositories/Interfaces/IReadOnlyRepository.cs
+++ b/RapidRepo/Repositories/Interfaces/IReadOnlyRepository.cs
@@ -12,7 +12,7 @@ namespace RapidRepo.Repositories.Interfaces;
 /// <typeparam name="TKey">The type of the entity identifier.</typeparam>
 public interface IReadOnlyRepository<TEntity, in TKey>
     where TEntity : BaseEntity<TKey>
-    where TKey : struct
+    where TKey : notnull
 {
     /// <summary>
     /// Checks if any entity matches the specified condition.

--- a/RapidRepo/Repositories/Interfaces/IRepository.cs
+++ b/RapidRepo/Repositories/Interfaces/IRepository.cs
@@ -9,7 +9,7 @@ namespace RapidRepo.Repositories.Interfaces;
 /// <typeparam name="TKey">The type of the entity identifier.</typeparam>
 public interface IRepository<TEntity, in TKey> : IReadOnlyRepository<TEntity, TKey>, IWriteRepository<TEntity, TKey>
     where TEntity : BaseEntity<TKey>
-    where TKey : struct
+    where TKey : notnull
 {
 
 }

--- a/RapidRepo/Repositories/Interfaces/IWriteRepository.cs
+++ b/RapidRepo/Repositories/Interfaces/IWriteRepository.cs
@@ -37,7 +37,7 @@ public interface IWriteRepository<TEntity, in TKey>
     /// <param name="entities">The entities to add.</param>
     /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    Task AddAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default);
+    Task AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Deletes an entity by its identifier.

--- a/RapidRepo/Repositories/Interfaces/IWriteRepository.cs
+++ b/RapidRepo/Repositories/Interfaces/IWriteRepository.cs
@@ -9,7 +9,7 @@ namespace RapidRepo.Repositories.Interfaces;
 /// <typeparam name="TKey">The type of the entity's identifier.</typeparam>
 public interface IWriteRepository<TEntity, in TKey>
     where TEntity : BaseEntity<TKey>
-    where TKey : struct
+    where TKey : notnull
 {
     /// <summary>
     /// Adds a new entity to the repository.

--- a/RapidRepo/Repositories/ReadOnlyRepository.cs
+++ b/RapidRepo/Repositories/ReadOnlyRepository.cs
@@ -9,7 +9,7 @@ using System.Linq.Expressions;
 namespace RapidRepo.Repositories;
 public abstract class ReadOnlyRepository<TEntity, TId>(DbContext dbContext) : IReadOnlyRepository<TEntity, TId>
     where TEntity : BaseEntity<TId>
-    where TId : struct
+    where TId : notnull
 {
     protected readonly DbContext DbContext = dbContext;
 

--- a/RapidRepo/Repositories/ReadOnlyRepository.cs
+++ b/RapidRepo/Repositories/ReadOnlyRepository.cs
@@ -11,10 +11,12 @@ public abstract class ReadOnlyRepository<TEntity, TId>(DbContext dbContext) : IR
     where TEntity : BaseEntity<TId>
     where TId : notnull
 {
-    protected readonly DbContext DbContext = dbContext;
+    protected readonly DbContext DbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
 
     public virtual bool Any(Expression<Func<TEntity, bool>> condition)
     {
+        ArgumentNullException.ThrowIfNull(condition);
+
         return DbContext.Set<TEntity>().AsNoTracking().Any(condition);
     }
 
@@ -22,6 +24,8 @@ public abstract class ReadOnlyRepository<TEntity, TId>(DbContext dbContext) : IR
         Expression<Func<TEntity, bool>> condition,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(condition);
+
         return await DbContext.Set<TEntity>().AsNoTracking().AnyAsync(condition, cancellationToken);
     }
 
@@ -106,6 +110,8 @@ public abstract class ReadOnlyRepository<TEntity, TId>(DbContext dbContext) : IR
         bool track = true,
         bool ignoreQueryFilters = false)
     {
+        ArgumentNullException.ThrowIfNull(id);
+
         return DbContext
             .Set<TEntity>()
             .AsQueryable()
@@ -114,7 +120,7 @@ public abstract class ReadOnlyRepository<TEntity, TId>(DbContext dbContext) : IR
                 useSplitQueries: useSplitQueries,
                 ignoreQueryFilters: ignoreQueryFilters,
                 track: track)
-            .FirstOrDefault(e => e.Id.Equals(id));
+            .FirstOrDefault(e => id.Equals(e.Id));
     }
 
     public virtual TResult? GetById<TResult>(
@@ -124,6 +130,9 @@ public abstract class ReadOnlyRepository<TEntity, TId>(DbContext dbContext) : IR
         bool useSplitQueries = false,
         bool ignoreQueryFilters = false)
     {
+        ArgumentNullException.ThrowIfNull(id);
+        ArgumentNullException.ThrowIfNull(selector);
+
         return DbContext
             .Set<TEntity>()
             .AsQueryable()
@@ -132,7 +141,7 @@ public abstract class ReadOnlyRepository<TEntity, TId>(DbContext dbContext) : IR
                 useSplitQueries: useSplitQueries,
                 ignoreQueryFilters: ignoreQueryFilters,
                 track: false)
-            .Where(e => e.Id.Equals(id))
+            .Where(e => id.Equals(e.Id))
             .Select(selector)
             .FirstOrDefault();
     }
@@ -145,6 +154,8 @@ public abstract class ReadOnlyRepository<TEntity, TId>(DbContext dbContext) : IR
         bool ignoreQueryFilters = false,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(id);
+
         return await DbContext
             .Set<TEntity>()
             .AsQueryable()
@@ -153,7 +164,7 @@ public abstract class ReadOnlyRepository<TEntity, TId>(DbContext dbContext) : IR
                 useSplitQueries: useSplitQueries,
                 ignoreQueryFilters: ignoreQueryFilters,
                 track: track)
-            .FirstOrDefaultAsync(e => e.Id.Equals(id), cancellationToken);
+            .FirstOrDefaultAsync(e => id.Equals(e.Id), cancellationToken);
     }
 
     public virtual TEntity GetFirst(
@@ -410,6 +421,9 @@ public abstract class ReadOnlyRepository<TEntity, TId>(DbContext dbContext) : IR
         bool ignoreQueryFilters = false,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(id);
+        ArgumentNullException.ThrowIfNull(selector);
+
         return DbContext
             .Set<TEntity>()
             .AsQueryable()
@@ -418,7 +432,7 @@ public abstract class ReadOnlyRepository<TEntity, TId>(DbContext dbContext) : IR
                 useSplitQueries: useSplitQueries,
                 ignoreQueryFilters: ignoreQueryFilters,
                 track: false)
-            .Where(e => e.Id.Equals(id))
+            .Where(e => id.Equals(e.Id))
             .Select(selector)
             .FirstOrDefaultAsync(cancellationToken);
     }
@@ -431,6 +445,8 @@ public abstract class ReadOnlyRepository<TEntity, TId>(DbContext dbContext) : IR
         bool useSplitQueries = false,
         bool ignoreQueryFilters = false)
     {
+        ArgumentNullException.ThrowIfNull(selector);
+
         return DbContext
             .Set<TEntity>()
             .AsQueryable()
@@ -454,6 +470,8 @@ public abstract class ReadOnlyRepository<TEntity, TId>(DbContext dbContext) : IR
         bool ignoreQueryFilters = false,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(selector);
+
         return DbContext
             .Set<TEntity>()
             .AsQueryable()
@@ -476,6 +494,8 @@ public abstract class ReadOnlyRepository<TEntity, TId>(DbContext dbContext) : IR
         bool useSplitQueries = false,
         bool ignoreQueryFilters = false)
     {
+        ArgumentNullException.ThrowIfNull(selector);
+
         return DbContext
             .Set<TEntity>()
             .AsQueryable()
@@ -499,6 +519,8 @@ public abstract class ReadOnlyRepository<TEntity, TId>(DbContext dbContext) : IR
         bool ignoreQueryFilters = false,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(selector);
+
         return DbContext
             .Set<TEntity>()
             .AsQueryable()
@@ -521,6 +543,8 @@ public abstract class ReadOnlyRepository<TEntity, TId>(DbContext dbContext) : IR
         bool useSplitQueries = false,
         bool ignoreQueryFilters = false)
     {
+        ArgumentNullException.ThrowIfNull(selector);
+
         return DbContext
             .Set<TEntity>()
             .AsQueryable()
@@ -544,6 +568,8 @@ public abstract class ReadOnlyRepository<TEntity, TId>(DbContext dbContext) : IR
         bool ignoreQueryFilters = false,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(selector);
+
         return await DbContext
             .Set<TEntity>()
             .AsQueryable()
@@ -566,6 +592,8 @@ public abstract class ReadOnlyRepository<TEntity, TId>(DbContext dbContext) : IR
         bool useSplitQueries = false,
         bool ignoreQueryFilters = false)
     {
+        ArgumentNullException.ThrowIfNull(selector);
+
         return DbContext
             .Set<TEntity>()
             .AsQueryable()
@@ -589,6 +617,8 @@ public abstract class ReadOnlyRepository<TEntity, TId>(DbContext dbContext) : IR
         bool ignoreQueryFilters = false,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(selector);
+
         return await DbContext
             .Set<TEntity>()
             .AsQueryable()
@@ -611,6 +641,8 @@ public abstract class ReadOnlyRepository<TEntity, TId>(DbContext dbContext) : IR
         bool useSplitQueries = false,
         bool ignoreQueryFilters = false)
     {
+        ArgumentNullException.ThrowIfNull(selector);
+
         return DbContext
             .Set<TEntity>()
             .AsQueryable()
@@ -634,6 +666,8 @@ public abstract class ReadOnlyRepository<TEntity, TId>(DbContext dbContext) : IR
         bool ignoreQueryFilters = false,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(selector);
+
         var query = DbContext
             .Set<TEntity>()
             .AsQueryable()

--- a/RapidRepo/Repositories/WriteRepository.cs
+++ b/RapidRepo/Repositories/WriteRepository.cs
@@ -31,7 +31,7 @@ public abstract class WriteRepository<TEntity, TId>(DbContext dbContext) : IWrit
         await DbContext.Set<TEntity>().AddAsync(entity, cancellationToken);
     }
 
-    public virtual async Task AddAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
+    public virtual async Task AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(entities);
         await DbContext.Set<TEntity>().AddRangeAsync(entities, cancellationToken);

--- a/RapidRepo/Repositories/WriteRepository.cs
+++ b/RapidRepo/Repositories/WriteRepository.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using RapidRepo.Entities;
 using RapidRepo.Entities.Interfaces;
 using RapidRepo.Repositories.Interfaces;
@@ -7,11 +7,10 @@ namespace RapidRepo.Repositories;
 
 public abstract class WriteRepository<TEntity, TId>(DbContext dbContext) : IWriteRepository<TEntity, TId>
     where TEntity : BaseEntity<TId>
-    where TId : struct
+    where TId : notnull
 {
     protected readonly DbContext DbContext = dbContext;
     protected readonly bool SupportsSoftDelete =
-            typeof(IDeletableEntity<TId>).IsAssignableFrom(typeof(TEntity)) ||
             typeof(IDeletableEntity).IsAssignableFrom(typeof(TEntity));
 
     public virtual void Add(TEntity entity)

--- a/RapidRepo/Repositories/WriteRepository.cs
+++ b/RapidRepo/Repositories/WriteRepository.cs
@@ -9,32 +9,38 @@ public abstract class WriteRepository<TEntity, TId>(DbContext dbContext) : IWrit
     where TEntity : BaseEntity<TId>
     where TId : notnull
 {
-    protected readonly DbContext DbContext = dbContext;
+    protected readonly DbContext DbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
     protected readonly bool SupportsSoftDelete =
             typeof(IDeletableEntity).IsAssignableFrom(typeof(TEntity));
 
     public virtual void Add(TEntity entity)
     {
+        ArgumentNullException.ThrowIfNull(entity);
         DbContext.Set<TEntity>().Add(entity);
     }
 
     public virtual void AddRange(IEnumerable<TEntity> entities)
     {
+        ArgumentNullException.ThrowIfNull(entities);
         DbContext.Set<TEntity>().AddRange(entities);
     }
 
     public virtual async Task AddAsync(TEntity entity, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(entity);
         await DbContext.Set<TEntity>().AddAsync(entity, cancellationToken);
     }
 
     public virtual async Task AddAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(entities);
         await DbContext.Set<TEntity>().AddRangeAsync(entities, cancellationToken);
     }
 
     public virtual void Delete(TEntity entity)
     {
+        ArgumentNullException.ThrowIfNull(entity);
+
         if (SupportsSoftDelete)
         {
             if (DbContext.Entry(entity).State == EntityState.Detached)
@@ -52,6 +58,8 @@ public abstract class WriteRepository<TEntity, TId>(DbContext dbContext) : IWrit
 
 public virtual void DeleteRange(IEnumerable<TEntity> entities)
 {
+    ArgumentNullException.ThrowIfNull(entities);
+
     var entitiesToRemove = entities.ToList();
 
     if (SupportsSoftDelete)
@@ -73,11 +81,14 @@ public virtual void DeleteRange(IEnumerable<TEntity> entities)
 
     public virtual void Update(TEntity entity)
     {
+        ArgumentNullException.ThrowIfNull(entity);
         DbContext.Set<TEntity>().Update(entity);
     }
 
     public virtual void DeleteById(TId id)
     {
+        ArgumentNullException.ThrowIfNull(id);
+
         var entity = DbContext.Set<TEntity>().Find(id);
         if (entity != null)
         {
@@ -87,6 +98,7 @@ public virtual void DeleteRange(IEnumerable<TEntity> entities)
 
     public virtual void UpdateRange(IEnumerable<TEntity> entities)
     {
+        ArgumentNullException.ThrowIfNull(entities);
         DbContext.Set<TEntity>().UpdateRange(entities);
     }
 }

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -102,7 +102,7 @@ var newProducts = new List<Product>
     new() { Name = "Widget B", Price = 14.99m },
 };
 
-await _unitOfWork.Products.AddAsync(newProducts);
+await _unitOfWork.Products.AddRangeAsync(newProducts);
 await _unitOfWork.CommitAsync(userId: currentUserId);
 
 // Update multiple entities
@@ -149,4 +149,3 @@ public class ProductRepository : BaseRepository<Product, long>, IProductReposito
     public async Task<bool> SkuExistsAsync(string sku)
         => await AnyAsync(p => p.Sku == sku);
 }
-```

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -34,7 +34,7 @@ IEnumerable<Product> active = await _unitOfWork.Products.GetAllAsync(
 
 ### GetAllPaged
 
-Returns a `Paged<TEntity>` (or `Paged<TResult>` with a selector). Page index is 1-based.
+Returns a `Paged<TEntity>`. Page index is 1-based.
 
 ```csharp
 Paged<Product> page = await _unitOfWork.Products.GetAllPagedAsync(
@@ -130,7 +130,7 @@ IEnumerable<string> names = await _unitOfWork.Products.GetAllAsync(
 | `Add(entity)` | Stages a single entity for insert |
 | `AddRange(entities)` | Stages multiple entities for insert |
 | `AddAsync(entity)` | Async version of `Add` |
-| `AddAsync(entities)` | Async version of `AddRange` |
+| `AddRangeAsync(entities)` | Async version of `AddRange` |
 | `Update(entity)` | Marks a single entity as modified |
 | `UpdateRange(entities)` | Marks multiple entities as modified |
 | `Delete(entity)` | Marks a single entity for removal |

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -6,10 +6,10 @@ All entities used with RapidRepo must inherit from one of the provided base clas
 
 ## `BaseEntity<TKey>`
 
-The simplest base class. Provides only an `Id` property. `TKey` must be a value type (e.g. `int`, `long`, `Guid`).
+The simplest base class. Provides only an `Id` property. `TKey` can be any non-null key type (for example `int`, `long`, `Guid`, or `string`).
 
 ```csharp
-public class Product : BaseEntity<long>
+public class Product : BaseEntity<string>
 {
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
@@ -40,7 +40,7 @@ public class Product : BaseAuditableEntity<long>
 
 ## `BaseAuditableEntity<TId, TUserKey>`
 
-Inherits directly from `BaseEntity<TId>` and implements `IAuditableEntity<TUserKey>` to track which user performed each operation. Both `TId` and `TUserKey` must be value types. Note: this variant does **not** include a `DeletedAt` property — see [Soft Delete](#soft-delete-ideletableentity) below.
+Inherits directly from `BaseEntity<TId>` and implements `IAuditableEntity<TUserKey>` to track which user performed each operation. `TId` can be any non-null key type, while `TUserKey` must be a value type. Note: this variant does **not** include a `DeletedAt` property — see [Soft Delete](#soft-delete-ideletableentity) below.
 
 | Property | Type | Set on |
 |---|---|---|


### PR DESCRIPTION
BREAKING CHANGE: Entity/auditable base type constraints and namespaces changed. Consumers may need to update entity declarations/usings.

This pull request adds support for non-null entity key types (such as `string` and `Guid`) throughout the RapidRepo library and its test suite. The main change is updating type constraints from value types (`struct`) to non-nullable types (`notnull`), allowing for greater flexibility in entity key types. The PR also introduces new test entities and repositories using string keys, and adds corresponding tests to ensure correct CRUD operations with these key types.

### Core Library Updates

* Changed type constraints on entity and repository generics from `struct` to `notnull`, enabling use of non-nullable reference types (e.g., `string` and `Guid`) as entity keys in `BaseEntity<TId>`, `BaseAuditableEntity<TId>`, repository classes, and interfaces. [[1]](diffhunk://#diff-e7e1d87df73ddac41165ade51e6c43880798d60cd6de30bbda143bfaed952f1dL1-R11) [[2]](diffhunk://#diff-e7e1d87df73ddac41165ade51e6c43880798d60cd6de30bbda143bfaed952f1dL41-R40) [[3]](diffhunk://#diff-3e9c7770455ac119427dc66daada81530e9a8bcf8d90939cc007a210ab999459L8-R8) [[4]](diffhunk://#diff-0b1d6cef45310881d969504d2dd57bd6ec9536a307c1e9020a2ce55461c51dbeL18-R18) [[5]](diffhunk://#diff-6c1d346e813d91ae9e18d92da208fe9dcff96281f8e47841dd9df3917d3a967fL9-R9) [[6]](diffhunk://#diff-15b03608f77371a99734c46e23b994f95faf0f739db0cea58e1fe5303149afadL18-R18) [[7]](diffhunk://#diff-524940936d8262b5b9bc4c2c85f01315a7f0c2c1d2c3a6030219c2597a1186a5L15-R15) [[8]](diffhunk://#diff-c78236185a7b7948e00e8330a65173d1a3496ee2d9a12e6c19bbdabdae6633d0L12-R12) [[9]](diffhunk://#diff-4be567ad06d0c5ed7f0683fa70fc3d0dc077d5d6152eb3c644a0e46f77b992ebL12-R12) [[10]](diffhunk://#diff-13de00956dc34e74f497951f63d4e5e93aabcdcf86a8c0b9916fd481b94648b4L12-R12) [[11]](diffhunk://#diff-b6f2c1614b7600f16bed649351a01829360a1b9f2c1ca8db9cc3ac768a08aa3fL10-L14)

* Updated documentation in `README.md` to mention support for non-null entity key types.

### Test Infrastructure

* Added new `AccessToken` entity with a string key, and registered it in `TestDbContext`. [[1]](diffhunk://#diff-9b23347dce7bfea5c749119e603e56022eb7c30ee408d11df2fdbf53642a91abR1-R8) [[2]](diffhunk://#diff-4e13e955a8f3c69e09e193f595c621685eec45e7017a25fbd92ec08e41f8a789R9) [[3]](diffhunk://#diff-4e13e955a8f3c69e09e193f595c621685eec45e7017a25fbd92ec08e41f8a789R22)

* Created repository implementations for `AccessToken` with string keys for base, read-only, and write repositories. [[1]](diffhunk://#diff-907f96bff112209421ee068b57c1e51fcb4c00292c6ac6fddabd4ba0ec343636R1-R12) [[2]](diffhunk://#diff-0c271921e3a5418ea11b502e0f2d7c7c13153de0db7f753009c89e197ae56f40R1-R13) [[3]](diffhunk://#diff-95201bf73bddeadf095fa6e171a7a96ec23d2f2660ef52a3684c2a47c1ab3dd2R1-R13)

### Test Coverage

* Added and updated tests for CRUD operations (`GetById`, `DeleteById`) to verify correct behavior with string-keyed entities in base, read-only, and write repositories. [[1]](diffhunk://#diff-b09fc6705d1e8cb425d1130301664d7bf0ff09f98e6366b59bc8ed28b523ca52R42-R65) [[2]](diffhunk://#diff-397ab868138fa7644eeb2133cf18e860f56df5ea038d7d6c76e790381c38641cR99-R120) [[3]](diffhunk://#diff-4576440c4f5d4af859a330e31c10358d4a03417d78f16fcc4fc0e6f0b93b74daR99-R120) [[4]](diffhunk://#diff-5aa6bf297676ea81feb01d4572ff8692fba7d99f91ce9633bc17110d13d295f8R42-R65)

* Updated test files to use the new test data and repository implementations. [[1]](diffhunk://#diff-b09fc6705d1e8cb425d1130301664d7bf0ff09f98e6366b59bc8ed28b523ca52L1-R2) [[2]](diffhunk://#diff-397ab868138fa7644eeb2133cf18e860f56df5ea038d7d6c76e790381c38641cR2) [[3]](diffhunk://#diff-4576440c4f5d4af859a330e31c10358d4a03417d78f16fcc4fc0e6f0b93b74daR2) [[4]](diffhunk://#diff-5aa6bf297676ea81feb01d4572ff8692fba7d99f91ce9633bc17110d13d295f8R2)

---

These changes make the repository pattern implementation more flexible and robust by supporting a wider range of entity key types, and ensure this support is well tested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository framework now supports any non-null key type (including reference keys like string)
  * Batch-add API renamed to AddRangeAsync for multi-entity inserts

* **Tests**
  * Expanded coverage for string-key scenarios across read/write/delete operations
  * Added comprehensive null-argument validation tests for repository APIs

* **Documentation**
  * Updated docs and README to reflect non-null key support and API rename
<!-- end of auto-generated comment: release notes by coderabbit.ai -->