### PR TITLE
feat!: complete entity hierarchy, add multi-targeting, and improve API

### DIFF
--- a/RapidRepo.Extensions.DependencyInjection/RapidRepo.Extensions.DependencyInjection.csproj
+++ b/RapidRepo.Extensions.DependencyInjection/RapidRepo.Extensions.DependencyInjection.csproj
@@ -2,14 +2,25 @@
 
   <PropertyGroup>
     <Authors>Tibor Horváth</Authors>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.*" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\RapidRepo\RapidRepo.csproj" />
   </ItemGroup>
 

--- a/RapidRepo.Tests/RapidRepo.Tests.csproj
+++ b/RapidRepo.Tests/RapidRepo.Tests.csproj
@@ -15,8 +15,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/RapidRepo/Entities/BaseAuditableDeletableEntity.cs
+++ b/RapidRepo/Entities/BaseAuditableDeletableEntity.cs
@@ -1,13 +1,13 @@
-﻿using RapidRepo.Entities.Interfaces;
+using RapidRepo.Entities.Interfaces;
 
 namespace RapidRepo.Entities;
 
 /// <summary>
-/// Represents a base auditable entity with common audit fields.
+/// Represents a base entity with audit fields and soft-delete support, tracked by user.
 /// </summary>
 /// <typeparam name="TId">The type of the entity's identifier.</typeparam>
 /// <typeparam name="TUserKey">The type of the user identifier.</typeparam>
-public class BaseAuditableEntity<TId, TUserKey> : BaseEntity<TId>, IAuditableEntity<TUserKey>
+public class BaseAuditableDeletableEntity<TId, TUserKey> : BaseEntity<TId>, IAuditableDeletableEntity<TUserKey>
     where TId : notnull
     where TUserKey : struct
 {
@@ -30,13 +30,23 @@ public class BaseAuditableEntity<TId, TUserKey> : BaseEntity<TId>, IAuditableEnt
     /// Gets or sets the user who last modified the entity.
     /// </summary>
     public TUserKey? ModifiedBy { get; set; }
+
+    /// <summary>
+    /// Gets or sets the date and time when the entity was deleted.
+    /// </summary>
+    public DateTime? DeletedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the user who deleted the entity.
+    /// </summary>
+    public TUserKey? DeletedBy { get; set; }
 }
 
 /// <summary>
-/// Represents a base auditable entity with common audit fields.
+/// Represents a base entity with audit fields and soft-delete support.
 /// </summary>
 /// <typeparam name="TId">The type of the entity's identifier.</typeparam>
-public class BaseAuditableEntity<TId> : BaseEntity<TId>, IAuditableEntity
+public class BaseAuditableDeletableEntity<TId> : BaseEntity<TId>, IAuditableDeletableEntity
     where TId : notnull
 {
     /// <summary>
@@ -48,4 +58,9 @@ public class BaseAuditableEntity<TId> : BaseEntity<TId>, IAuditableEntity
     /// Gets or sets the date and time when the entity was last modified.
     /// </summary>
     public DateTime? ModifiedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the date and time when the entity was deleted.
+    /// </summary>
+    public DateTime? DeletedAt { get; set; }
 }

--- a/RapidRepo/Extensions/ModelBuilderExtensions.cs
+++ b/RapidRepo/Extensions/ModelBuilderExtensions.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore;
+using RapidRepo.Entities.Interfaces;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace RapidRepo.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="ModelBuilder"/> to simplify common configuration patterns.
+/// </summary>
+public static class ModelBuilderExtensions
+{
+    /// <summary>
+    /// Applies a global query filter on all entity types that implement <see cref="IDeletableEntity"/>
+    /// so that soft-deleted records are excluded from queries by default.
+    /// Call this from <c>OnModelCreating</c> in your <see cref="DbContext"/>.
+    /// </summary>
+    /// <param name="modelBuilder">The model builder.</param>
+    public static ModelBuilder AddSoftDeleteQueryFilters(this ModelBuilder modelBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(modelBuilder);
+
+        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            if (!typeof(IDeletableEntity).IsAssignableFrom(entityType.ClrType))
+                continue;
+
+            var parameter = Expression.Parameter(entityType.ClrType, "e");
+            var deletedAtProperty = Expression.Property(parameter, nameof(IDeletableEntity.DeletedAt));
+            var nullConstant = Expression.Constant(null, typeof(DateTime?));
+            var isNotDeleted = Expression.Equal(deletedAtProperty, nullConstant);
+            var lambda = Expression.Lambda(isNotDeleted, parameter);
+
+            modelBuilder.Entity(entityType.ClrType).HasQueryFilter(lambda);
+        }
+
+        return modelBuilder;
+    }
+}

--- a/RapidRepo/RapidRepo.csproj
+++ b/RapidRepo/RapidRepo.csproj
@@ -2,15 +2,25 @@
 
   <PropertyGroup>
     <Authors>Tibor Horváth</Authors>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RapidRepo/Repositories/BaseRepository.cs
+++ b/RapidRepo/Repositories/BaseRepository.cs
@@ -35,5 +35,8 @@ public abstract class BaseRepository<TEntity, TId> : ReadOnlyRepository<TEntity,
 
     public virtual void DeleteById(TId id) => _writeRepository.DeleteById(id);
 
+    public virtual Task DeleteByIdAsync(TId id, CancellationToken cancellationToken = default) =>
+        _writeRepository.DeleteByIdAsync(id, cancellationToken);
+
     public virtual void UpdateRange(IEnumerable<TEntity> entities) => _writeRepository.UpdateRange(entities);
 }

--- a/RapidRepo/Repositories/Interfaces/IWriteRepository.cs
+++ b/RapidRepo/Repositories/Interfaces/IWriteRepository.cs
@@ -46,6 +46,14 @@ public interface IWriteRepository<TEntity, in TKey>
     void DeleteById(TKey id);
 
     /// <summary>
+    /// Deletes an entity by its identifier asynchronously.
+    /// </summary>
+    /// <param name="id">The identifier of the entity to delete.</param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task DeleteByIdAsync(TKey id, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Deletes an entity from the repository.
     /// </summary>
     /// <param name="entity">The entity to delete.</param>

--- a/RapidRepo/Repositories/ReadOnlyRepository.cs
+++ b/RapidRepo/Repositories/ReadOnlyRepository.cs
@@ -263,6 +263,9 @@ public abstract class ReadOnlyRepository<TEntity, TId>(DbContext dbContext) : IR
         int pageIndex = 1,
         int pageSize = 10)
     {
+        ArgumentOutOfRangeException.ThrowIfLessThan(pageIndex, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(pageSize, 1);
+
         var query = DbContext
             .Set<TEntity>()
             .AsQueryable()
@@ -300,6 +303,9 @@ public abstract class ReadOnlyRepository<TEntity, TId>(DbContext dbContext) : IR
         int pageSize = 10,
         CancellationToken cancellationToken = default)
     {
+        ArgumentOutOfRangeException.ThrowIfLessThan(pageIndex, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(pageSize, 1);
+
         var query = DbContext
             .Set<TEntity>()
             .AsQueryable()
@@ -683,4 +689,18 @@ public abstract class ReadOnlyRepository<TEntity, TId>(DbContext dbContext) : IR
             .Select(selector)
             .ToListAsync(cancellationToken);
     }
+
+    /// <summary>
+    /// Builds a queryable for <typeparamref name="TEntity"/> with the standard filters applied.
+    /// Use this in custom repository methods to avoid duplicating the filter-chaining logic.
+    /// </summary>
+    protected IQueryable<TEntity> BuildQuery(
+        Expression<Func<TEntity, bool>>? condition = null,
+        Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
+        Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>>? include = null,
+        bool useSplitQueries = false,
+        bool ignoreQueryFilters = false,
+        bool track = true)
+        => DbContext.Set<TEntity>().AsQueryable()
+            .ApplyFilters<TEntity, TId>(condition, orderBy, include, useSplitQueries, ignoreQueryFilters, track);
 }

--- a/RapidRepo/Repositories/WriteRepository.cs
+++ b/RapidRepo/Repositories/WriteRepository.cs
@@ -96,6 +96,17 @@ public virtual void DeleteRange(IEnumerable<TEntity> entities)
         }
     }
 
+    public virtual async Task DeleteByIdAsync(TId id, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+
+        var entity = await DbContext.Set<TEntity>().FindAsync([id], cancellationToken);
+        if (entity != null)
+        {
+            Delete(entity);
+        }
+    }
+
     public virtual void UpdateRange(IEnumerable<TEntity> entities)
     {
         ArgumentNullException.ThrowIfNull(entities);

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -55,6 +55,10 @@ Console.WriteLine($"Page {page.Page} of {page.TotalPages} ({page.TotalCount} tot
 Console.WriteLine($"Has next: {page.HasNext}, Has previous: {page.HasPrevious}");
 ```
 
+> **Two-query pattern:** `GetAllPaged` / `GetAllPagedAsync` always issue two SQL statements — a `COUNT(*)` to get the total, then a `SELECT ... OFFSET ... FETCH` to get the page. For very large tables or high-latency connections this can be significant. If you already know the total count (e.g. from a cache), avoid the double round-trip by writing a custom repository method that skips the count query and constructs `Paged<T>` directly using `BuildQuery`.
+>
+> `pageIndex` must be ≥ 1 and `pageSize` must be ≥ 1; passing a lower value throws `ArgumentOutOfRangeException`.
+
 ---
 
 ## Disabling change tracking (read-only queries)
@@ -127,13 +131,14 @@ If no `userId` is passed, `DefaultUserKey` (defined in your `UnitOfWork` impleme
 
 ## Custom repository methods
 
-Encapsulate domain-specific queries inside the repository, reusing the built-in helpers:
+Encapsulate domain-specific queries inside the repository. Use the `BuildQuery` helper (available on `ReadOnlyRepository` and `BaseRepository`) to apply the standard filter chain — tracking, includes, query filters, split queries — without duplicating it:
 
 ```csharp
 public interface IProductRepository : IRepository<Product, long>
 {
     Task<IEnumerable<Product>> GetActiveByCategoryAsync(long categoryId);
     Task<bool> SkuExistsAsync(string sku);
+    Task<List<ProductSummary>> SearchAsync(string term, int limit);
 }
 
 public class ProductRepository : BaseRepository<Product, long>, IProductRepository
@@ -148,4 +153,33 @@ public class ProductRepository : BaseRepository<Product, long>, IProductReposito
 
     public async Task<bool> SkuExistsAsync(string sku)
         => await AnyAsync(p => p.Sku == sku);
+
+    public async Task<List<ProductSummary>> SearchAsync(string term, int limit)
+        => await BuildQuery(
+                condition: p => p.Name.Contains(term),
+                orderBy: q => q.OrderByDescending(p => p.CreatedAt),
+                track: false)
+            .Select(p => new ProductSummary(p.Id, p.Name, p.Price))
+            .Take(limit)
+            .ToListAsync();
 }
+```
+
+---
+
+## Setting up soft-delete query filters
+
+Register the soft-delete filter in your `DbContext.OnModelCreating` to exclude soft-deleted records from all queries by default:
+
+```csharp
+protected override void OnModelCreating(ModelBuilder modelBuilder)
+{
+    base.OnModelCreating(modelBuilder);
+
+    // Adds a HasQueryFilter(e => e.DeletedAt == null) to every entity
+    // that implements IDeletableEntity — no per-entity configuration needed.
+    modelBuilder.AddSoftDeleteQueryFilters();
+}
+```
+
+To include soft-deleted records in a specific query, pass `ignoreQueryFilters: true` (see the section above).


### PR DESCRIPTION
BREAKING CHANGES:
- Remove DeletedAt from BaseAuditableEntity<TId>; use BaseAuditableDeletableEntity<TId> instead
- Add DeleteByIdAsync to IWriteRepository; direct implementors must add the method

New:
- Add BaseAuditableDeletableEntity<TId> and BaseAuditableDeletableEntity<TId, TUserKey>
- Add IWriteRepository.DeleteByIdAsync / WriteRepository.DeleteByIdAsync
- Add ReadOnlyRepository.BuildQuery protected helper for custom repository methods
- Add ModelBuilderExtensions.AddSoftDeleteQueryFilters()
- Multi-target net8.0, net9.0, and net10.0

Fix:
- Throw ArgumentOutOfRangeException for invalid pageIndex/pageSize in GetAllPaged