### PR TITLE
feat(uow): add protected GetRepository<TEntity, TKey>() factory to UnitOfWork

### DIFF
--- a/RapidRepo.Tests/UnitOfWork/GetRepositoryTests.cs
+++ b/RapidRepo.Tests/UnitOfWork/GetRepositoryTests.cs
@@ -1,0 +1,65 @@
+using Microsoft.EntityFrameworkCore;
+using RapidRepo.Tests.Repositories.TestData;
+using RapidRepo.UnitOfWork;
+
+namespace RapidRepo.Tests.UnitOfWork;
+
+public class GetRepositoryTests
+{
+    private readonly FactoryUnitOfWork _sut;
+    private readonly TestDbContext _dbContext;
+
+    public GetRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(databaseName: $"TestDatabase-{Guid.NewGuid()}")
+            .EnableSensitiveDataLogging()
+            .Options;
+
+        _dbContext = new TestDbContext(options);
+        _dbContext.Database.EnsureCreated();
+
+        _sut = new FactoryUnitOfWork(_dbContext);
+    }
+
+    [Fact]
+    public async Task GetRepository_WhenEntityAdded_ShouldPersistWithAuditFields()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var employee = new Employee { FirstName = "Alice", LastName = "Smith" };
+
+        // Act
+        await _sut.Employees.AddAsync(employee);
+        await _sut.CommitAsync(userId);
+
+        // Assert
+        var saved = _dbContext.Employees.FirstOrDefault();
+        Assert.NotNull(saved);
+        Assert.Equal(userId, saved.CreatedBy);
+        Assert.True((DateTime.UtcNow - saved.CreatedAt).TotalSeconds < 5);
+    }
+
+    [Fact]
+    public async Task GetRepository_WhenQueried_ReturnsPersistedEntities()
+    {
+        // Arrange
+        var employee = new Employee { FirstName = "Bob", LastName = "Jones" };
+        await _sut.Employees.AddAsync(employee);
+        await _sut.CommitAsync();
+
+        // Act — call GetRepository again to get a fresh instance backed by the same DbContext
+        var result = _sut.Employees.Any(e => e.FirstName == "Bob");
+
+        // Assert
+        Assert.True(result);
+    }
+
+    private sealed class FactoryUnitOfWork(TestDbContext dbContext) : UnitOfWork<Guid>(dbContext)
+    {
+        public override Guid DefaultUserKey => Guid.Empty;
+
+        public RapidRepo.Repositories.Interfaces.IRepository<Employee, int> Employees
+            => GetRepository<Employee, int>();
+    }
+}

--- a/RapidRepo.Tests/UnitOfWork/GetRepositoryTests.cs
+++ b/RapidRepo.Tests/UnitOfWork/GetRepositoryTests.cs
@@ -26,6 +26,7 @@ public class GetRepositoryTests
     public async Task GetRepository_WhenEntityAdded_ShouldPersistWithAuditFields()
     {
         // Arrange
+        var utcBefore = DateTime.UtcNow;
         var userId = Guid.NewGuid();
         var employee = new Employee { FirstName = "Alice", LastName = "Smith" };
 
@@ -37,7 +38,7 @@ public class GetRepositoryTests
         var saved = _dbContext.Employees.FirstOrDefault();
         Assert.NotNull(saved);
         Assert.Equal(userId, saved.CreatedBy);
-        Assert.True((DateTime.UtcNow - saved.CreatedAt).TotalSeconds < 5);
+        Assert.True(saved.CreatedAt >= utcBefore && saved.CreatedAt <= DateTime.UtcNow);
     }
 
     [Fact]

--- a/RapidRepo/UnitOfWork/UnitOfWork.cs
+++ b/RapidRepo/UnitOfWork/UnitOfWork.cs
@@ -1,5 +1,8 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using RapidRepo.Entities;
 using RapidRepo.Entities.Interfaces;
+using RapidRepo.Repositories;
+using RapidRepo.Repositories.Interfaces;
 
 namespace RapidRepo.UnitOfWork;
 
@@ -29,6 +32,11 @@ public abstract class UnitOfWork<TUserKey> : IUnitOfWork<TUserKey>, IDisposable
         ExecuteAudit(userId);
         await DbContext.SaveChangesAsync(cancellationToken);
     }
+
+    protected IRepository<TEntity, TKey> GetRepository<TEntity, TKey>()
+        where TEntity : BaseEntity<TKey>
+        where TKey : notnull
+        => new Repository<TEntity, TKey>(DbContext);
 
     public void Dispose()
     {

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -91,3 +91,39 @@ public class Product : BaseAuditableEntity<long, Guid>, IDeletableEntity<Guid>
 | Track created/modified timestamps | `BaseAuditableEntity<TId>` |
 | Track who created/modified the record | `BaseAuditableEntity<TId, TUserKey>` |
 | Add soft delete to any of the above | Add `IDeletableEntity` or `IDeletableEntity<TUserKey>` |
+
+---
+
+## Reducing repetition with application-level base classes
+
+When all entities in your application use the same user-key type, you can define it once by
+creating thin abstract base classes that lock in `TUserKey`:
+
+```csharp
+// Guid-keyed users
+public abstract class AppAuditableEntity<TId> : BaseAuditableEntity<TId, Guid>
+    where TId : notnull { }
+
+public abstract class AppAuditableDeletableEntity<TId> : BaseAuditableDeletableEntity<TId, Guid>
+    where TId : notnull { }
+```
+
+```csharp
+// long-keyed users (e.g. database integer IDs)
+public abstract class AppAuditableEntity<TId> : BaseAuditableEntity<TId, long>
+    where TId : notnull { }
+
+public abstract class AppAuditableDeletableEntity<TId> : BaseAuditableDeletableEntity<TId, long>
+    where TId : notnull { }
+```
+
+Each entity then only needs to declare its primary-key type — the user-key type is inherited:
+
+```csharp
+public class Employee : AppAuditableEntity<int>  { }
+public class Product  : AppAuditableEntity<long> { }
+public class AuditLog : AppAuditableDeletableEntity<int> { }
+```
+
+Combined with `class AppUnitOfWork : UnitOfWork<Guid>` (or `UnitOfWork<long>`), the user-key
+type is declared in exactly two places across the whole application.

--- a/docs/unit-of-work.md
+++ b/docs/unit-of-work.md
@@ -48,23 +48,23 @@ entity and in the UoW — no extra type parameters are needed anywhere else.
 The pattern works with any value type for the user ID (`Guid`, `long`, `int`, etc.):
 
 ```csharp
-// Guid-keyed example
-public class AppUnitOfWork : UnitOfWork<Guid>, IAppUnitOfWork
+// Guid user keys
+public class GuidUnitOfWork : UnitOfWork<Guid>
 {
     public override Guid DefaultUserKey => Guid.Empty;
 
-    public AppUnitOfWork(AppDbContext dbContext) : base(dbContext) { }
+    public GuidUnitOfWork(AppDbContext dbContext) : base(dbContext) { }
 
     public IRepository<Employee, int>  Employees => GetRepository<Employee, int>();
     public IRepository<Product, long>  Products  => GetRepository<Product, long>();
 }
 
-// long-keyed example
-public class AppUnitOfWork : UnitOfWork<long>, IAppUnitOfWork
+// long user keys
+public class LongUnitOfWork : UnitOfWork<long>
 {
     public override long DefaultUserKey => 0;
 
-    public AppUnitOfWork(AppDbContext dbContext) : base(dbContext) { }
+    public LongUnitOfWork(AppDbContext dbContext) : base(dbContext) { }
 
     public IRepository<Employee, int>  Employees => GetRepository<Employee, int>();
     public IRepository<Product, long>  Products  => GetRepository<Product, long>();

--- a/docs/unit-of-work.md
+++ b/docs/unit-of-work.md
@@ -38,6 +38,44 @@ public class AppUnitOfWork : UnitOfWork<Guid>, IAppUnitOfWork
 
 ---
 
+## Repository factory (GetRepository)
+
+Instead of injecting each repository through the constructor, you can use the built-in
+`GetRepository<TEntity, TKey>()` factory method. This is especially useful when combined with
+application-level entity base classes, because the user-key type is already encoded in the
+entity and in the UoW — no extra type parameters are needed anywhere else.
+
+The pattern works with any value type for the user ID (`Guid`, `long`, `int`, etc.):
+
+```csharp
+// Guid-keyed example
+public class AppUnitOfWork : UnitOfWork<Guid>, IAppUnitOfWork
+{
+    public override Guid DefaultUserKey => Guid.Empty;
+
+    public AppUnitOfWork(AppDbContext dbContext) : base(dbContext) { }
+
+    public IRepository<Employee, int>  Employees => GetRepository<Employee, int>();
+    public IRepository<Product, long>  Products  => GetRepository<Product, long>();
+}
+
+// long-keyed example
+public class AppUnitOfWork : UnitOfWork<long>, IAppUnitOfWork
+{
+    public override long DefaultUserKey => 0;
+
+    public AppUnitOfWork(AppDbContext dbContext) : base(dbContext) { }
+
+    public IRepository<Employee, int>  Employees => GetRepository<Employee, int>();
+    public IRepository<Product, long>  Products  => GetRepository<Product, long>();
+}
+```
+
+> The existing constructor-injection pattern continues to work — `GetRepository` is an opt-in
+> convenience.
+
+---
+
 ## DI registration
 
 Register the `DbContext`, all repositories, and the Unit of Work with a scoped lifetime:


### PR DESCRIPTION


Allows concrete UoW subclasses to expose repositories directly without constructor-injecting them, keeping TUserKey declared in one place and eliminating per-repository field/constructor boilerplate.